### PR TITLE
Add option to replace instead of append

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,6 +66,7 @@ function App() {
     },
     endSignal: "</stream>",
     glue: " ",
+    replace: false,
   });
 
   return <div>{message}</div>;

--- a/packages/react/src/hooks/use-event-stream.ts
+++ b/packages/react/src/hooks/use-event-stream.ts
@@ -19,6 +19,7 @@ export const useEventStream = (
     eventName = "update",
     endSignal = "</stream>",
     glue = " ",
+    replace = false,
     onMessage = () => null,
     onComplete = () => null,
     onError = () => null,
@@ -43,6 +44,10 @@ export const useEventStream = (
         onComplete();
 
         return;
+      }
+
+      if (replace) {
+        resetMessageState();
       }
 
       messagePartsRef.current.push(

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,6 +2,7 @@ export type Options = {
   eventName?: string;
   endSignal?: string;
   glue?: string;
+  replace?: boolean;
   onMessage?: (event: MessageEvent) => void;
   onComplete?: () => void;
   onError?: (error: Event) => void;

--- a/packages/react/tests/use-event-stream.test.ts
+++ b/packages/react/tests/use-event-stream.test.ts
@@ -41,6 +41,28 @@ describe("useEventStream", () => {
     expect(result.current.messageParts).toEqual(["Hello", "World"]);
   });
 
+  it("processes incoming messages correctly with replace option", async () => {
+    const result = renderHook(() =>
+      useEventStream("/stream", { replace: true }),
+    ).result;
+
+    const eventHandler = mocks.addEventListener.mock.calls[0][1];
+
+    act(() => {
+      eventHandler({ data: "Hello" });
+    });
+
+    expect(result.current.message).toBe("Hello");
+    expect(result.current.messageParts).toEqual(["Hello"]);
+
+    act(() => {
+      eventHandler({ data: "World" });
+    });
+
+    expect(result.current.message).toBe("World");
+    expect(result.current.messageParts).toEqual(["World"]);
+  });
+
   it("can clear the message", async () => {
     const result = renderHook(() => useEventStream("/stream")).result;
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -68,6 +68,7 @@ const { message } = useEventStream("/stream", {
   },
   endSignal: "</stream>",
   glue: " ",
+  replace: false,
 });
 </script>
 ```

--- a/packages/vue/src/composables/useEventStream.ts
+++ b/packages/vue/src/composables/useEventStream.ts
@@ -19,6 +19,7 @@ export const useEventStream = (
     eventName = "update",
     endSignal = "</stream>",
     glue = " ",
+    replace = false,
     onMessage = () => null,
     onComplete = () => null,
     onError = () => null,
@@ -50,6 +51,10 @@ export const useEventStream = (
       closeConnection();
       onComplete();
       return;
+    }
+
+    if (replace) {
+      resetMessageState();
     }
 
     messageParts.value.push(

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -4,6 +4,7 @@ export type Options = {
   eventName?: string;
   endSignal?: string;
   glue?: string;
+  replace?: boolean;
   onMessage?: (event: MessageEvent) => void;
   onComplete?: () => void;
   onError?: (error: Event) => void;

--- a/packages/vue/tests/useEventStream.test.ts
+++ b/packages/vue/tests/useEventStream.test.ts
@@ -51,6 +51,24 @@ describe("useEventStream", () => {
     expect(result.messageParts.value).toEqual(["Hello", "World"]);
   });
 
+  it("processes incoming messages correctly with replace option", async () => {
+    const [result] = withSetup(() =>
+      useEventStream("/stream", { replace: true }),
+    );
+
+    const eventHandler = mocks.addEventListener.mock.calls[0][1];
+
+    eventHandler({ data: "Hello" });
+
+    expect(result.message.value).toBe("Hello");
+    expect(result.messageParts.value).toEqual(["Hello"]);
+
+    eventHandler({ data: "World" });
+
+    expect(result.message.value).toBe("World");
+    expect(result.messageParts.value).toEqual(["World"]);
+  });
+
   it("can clear the message", async () => {
     const [result] = withSetup(() => useEventStream("/stream"));
 


### PR DESCRIPTION
This PR adds a `replace` option to the second param that indicates that the message should be replaced instead of appended as data is received.