### PR TITLE
Add generic type for the `send` method

### DIFF
--- a/packages/react/src/hooks/use-stream.ts
+++ b/packages/react/src/hooks/use-stream.ts
@@ -17,9 +17,12 @@ import {
 } from "../streams/store";
 import { StreamMeta, StreamOptions } from "../types";
 
-export const useStream = <TJsonData = null>(
+export const useStream = <
+    TSendBody extends Record<string, any> = {},
+    TJsonData = null,
+>(
     url: string,
-    options: StreamOptions = {},
+    options: StreamOptions<TSendBody> = {},
 ) => {
     const id = useRef<string>(options.id ?? nanoid());
     const stream = useRef(resolveStream<TJsonData>(id.current));
@@ -79,7 +82,7 @@ export const useStream = <TJsonData = null>(
     }, []);
 
     const makeRequest = useCallback(
-        (body: Record<string, any> = {}) => {
+        (body?: TSendBody) => {
             const controller = new AbortController();
 
             const request: RequestInit = {
@@ -89,7 +92,7 @@ export const useStream = <TJsonData = null>(
                     ...headers.current,
                     ...(options.headers ?? {}),
                 },
-                body: JSON.stringify(body),
+                body: JSON.stringify(body ?? {}),
                 credentials: options.credentials ?? "same-origin",
             };
 
@@ -139,7 +142,7 @@ export const useStream = <TJsonData = null>(
         [url],
     );
 
-    const send = useCallback((body: Record<string, any>) => {
+    const send = useCallback((body: TSendBody) => {
         cancel();
         makeRequest(body);
         clearData();
@@ -243,11 +246,14 @@ export const useStream = <TJsonData = null>(
     };
 };
 
-export const useJsonStream = <TJsonData = null>(
+export const useJsonStream = <
+    TJsonData = null,
+    TSendBody extends Record<string, any> = {},
+>(
     url: string,
-    options: Omit<StreamOptions, "json"> = {},
+    options: Omit<StreamOptions<TSendBody>, "json"> = {},
 ) => {
-    const { jsonData, data, ...rest } = useStream<TJsonData>(url, {
+    const { jsonData, data, ...rest } = useStream<TSendBody, TJsonData>(url, {
         ...options,
         json: true,
     });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -15,9 +15,9 @@ export type EventStreamResult = {
     clearMessage: () => void;
 };
 
-export type StreamOptions = {
+export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     id?: string;
-    initialInput?: Record<string, any>;
+    initialInput?: TSendBody;
     headers?: Record<string, string>;
     csrfToken?: string;
     json?: boolean;

--- a/packages/vue/src/composables/useStream.ts
+++ b/packages/vue/src/composables/useStream.ts
@@ -17,16 +17,19 @@ import {
 } from "../streams/store";
 import { StreamMeta, StreamOptions } from "../types";
 
-export const useStream = <TJsonData = null>(
+export const useStream = <
+    TSendBody extends Record<string, any> = {},
+    TJsonData = null,
+>(
     url: string,
-    options: StreamOptions = {},
+    options: StreamOptions<TSendBody> = {},
 ): {
     data: Readonly<Ref<string>>;
     jsonData: Readonly<TJsonData | null>;
     isFetching: Readonly<Ref<boolean>>;
     isStreaming: Readonly<Ref<boolean>>;
     id: string;
-    send: (body: Record<string, any>) => void;
+    send: (body: TSendBody) => void;
     cancel: () => void;
     clearData: () => void;
 } => {
@@ -76,7 +79,7 @@ export const useStream = <TJsonData = null>(
         });
     };
 
-    const makeRequest = (body: Record<string, any> = {}) => {
+    const makeRequest = (body?: TSendBody) => {
         const controller = new AbortController();
 
         const request: RequestInit = {
@@ -86,7 +89,7 @@ export const useStream = <TJsonData = null>(
                 ...headers,
                 ...(options.headers ?? {}),
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify(body ?? {}),
             credentials: options.credentials ?? "same-origin",
         };
 
@@ -134,7 +137,7 @@ export const useStream = <TJsonData = null>(
             });
     };
 
-    const send = (body: Record<string, any>) => {
+    const send = (body: TSendBody) => {
         cancel();
         makeRequest(body);
         clearData();
@@ -225,11 +228,14 @@ export const useStream = <TJsonData = null>(
     };
 };
 
-export const useJsonStream = <TJsonData = null>(
+export const useJsonStream = <
+    TJsonData = null,
+    TSendBody extends Record<string, any> = {},
+>(
     url: string,
-    options: Omit<StreamOptions, "json"> = {},
+    options: Omit<StreamOptions<TSendBody>, "json"> = {},
 ) => {
-    const { jsonData, data, ...rest } = useStream<TJsonData>(url, {
+    const { jsonData, data, ...rest } = useStream<TSendBody, TJsonData>(url, {
         ...options,
         json: true,
     });

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -17,9 +17,9 @@ export type EventStreamResult = {
     clearMessage: () => void;
 };
 
-export type StreamOptions = {
+export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     id?: string;
-    initialInput?: Record<string, any>;
+    initialInput?: TSendBody;
     headers?: Record<string, string>;
     csrfToken?: string;
     json?: boolean;


### PR DESCRIPTION
This PR adds a generic type to the stream hooks that allows the user to specify the shape of the `send` method:

```ts
const { send } = useStream<{ messages: string[]}>();

send({
    messages: ['first', 'second', 'third']
})
```

It includes one small breaking change: Previously, the first generic type passed into `useStream` was to specify the JSON shape if using the `json` option, now the send payload is the first generic and the JSON shape is the second.

For `useJsonStream` the JSON payload remains the first generic, the send payload is the now the second.