### PR TITLE
Drop nanoid in favor of crypto.randomUUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "devDependencies": {
         "prettier": "^3.8.3"
     },
-    "dependencies": {
-        "nanoid": "^5.1.11"
-    },
     "pnpm": {
         "overrides": {
             "@eslint/plugin-kit@<0.3.4": ">=0.3.4",

--- a/packages/react/src/hooks/use-stream.ts
+++ b/packages/react/src/hooks/use-stream.ts
@@ -1,4 +1,3 @@
-import { nanoid } from "nanoid";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
     addCallbacks,
@@ -24,7 +23,7 @@ export const useStream = <
     url: string,
     options: StreamOptions<TSendBody> = {},
 ) => {
-    const id = useRef<string>(options.id ?? nanoid());
+    const id = useRef<string>(options.id ?? crypto.randomUUID());
     const stream = useRef(resolveStream<TJsonData>(id.current));
     const headers = useRef<HeadersInit>(
         (() => {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -64,8 +64,5 @@
     },
     "peerDependencies": {
         "svelte": "^5.0.0"
-    },
-    "dependencies": {
-        "nanoid": "^5.1.6"
     }
 }

--- a/packages/svelte/src/useStream.svelte.ts
+++ b/packages/svelte/src/useStream.svelte.ts
@@ -1,5 +1,4 @@
 import { derived, get, writable } from "svelte/store";
-import { nanoid } from "nanoid";
 import {
     addCallbacks,
     onBeforeSend,
@@ -53,7 +52,7 @@ export const useStream = <
     options: StreamOptions<TSendBody> = {},
 ): Stream<TJsonData, TSendBody> => {
     const getUrl = typeof url === "function" ? url : () => url;
-    const id = options.id ?? nanoid();
+    const id = options.id ?? crypto.randomUUID();
     const initialStream = resolveStream<TJsonData>(id);
 
     const streamStore = writable<StreamState<TJsonData>>({

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -61,8 +61,5 @@
     },
     "peerDependencies": {
         "vue": "^3.3.0"
-    },
-    "dependencies": {
-        "nanoid": "^5.1.6"
     }
 }

--- a/packages/vue/src/composables/useStream.ts
+++ b/packages/vue/src/composables/useStream.ts
@@ -1,4 +1,3 @@
-import { nanoid } from "nanoid";
 import {
     MaybeRefOrGetter,
     onMounted,
@@ -43,7 +42,7 @@ export const useStream = <
     clearData: () => void;
 } => {
     const urlRef = toRef(url);
-    const id = options.id ?? nanoid();
+    const id = options.id ?? crypto.randomUUID();
     const stream = ref<StreamMeta<TJsonData>>(resolveStream<TJsonData>(id));
     const headers = (() => {
         const headers: HeadersInit = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      nanoid:
-        specifier: ^5.1.11
-        version: 5.1.11
     devDependencies:
       prettier:
         specifier: ^3.8.3
@@ -84,10 +80,6 @@ importers:
         version: 4.0.18(@types/node@22.15.3)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.15.3)(typescript@5.9.3))
 
   packages/svelte:
-    dependencies:
-      nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -131,9 +123,6 @@ importers:
 
   packages/vue:
     dependencies:
-      nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
       vue:
         specifier: ^3.3.0
         version: 3.5.13(typescript@5.9.3)
@@ -1398,16 +1387,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.11:
-    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -1821,6 +1800,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -3063,10 +3043,6 @@ snapshots:
   mute-stream@2.0.0: {}
 
   nanoid@3.3.12: {}
-
-  nanoid@5.1.11: {}
-
-  nanoid@5.1.6: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION
Replace `nanoid` with the native `crypto.randomUUID()` for generating stream IDs across all three packages. Removes `nanoid` as a shipped dependency entirely.
