### PR TITLE
Fix flaky React test for initial input request

### DIFF
--- a/packages/react/tests/use-stream.test.ts
+++ b/packages/react/tests/use-stream.test.ts
@@ -70,7 +70,6 @@ describe("useStream", () => {
         await waitFor(() => expect(result.current.isFetching).toBe(true));
         await waitFor(() => expect(result.current.isFetching).toBe(false));
         await waitFor(() => expect(result.current.isStreaming).toBe(true));
-        await waitFor(() => expect(result.current.data).toBe("chunk1"));
         await waitFor(() => expect(result.current.isStreaming).toBe(false));
 
         expect(result.current.isStreaming).toBe(false);


### PR DESCRIPTION
Removes a mid-stream data assertion that was racy -- the mock server delivers chunks 20ms apart, and by the time `waitFor` polls, both chunks have already arrived. The final-state assertion below it already covers the full output.