### PR TITLE
Fix stream ID generation to work in non-secure contexts

### DIFF
--- a/packages/react/src/hooks/use-stream.ts
+++ b/packages/react/src/hooks/use-stream.ts
@@ -16,6 +16,11 @@ import {
 } from "../streams/store";
 import { StreamMeta, StreamOptions } from "../types";
 
+const generateId = (): string =>
+    Array.from(crypto.getRandomValues(new Uint8Array(8)), (b) =>
+        b.toString(16).padStart(2, "0"),
+    ).join("");
+
 export const useStream = <
     TSendBody extends Record<string, any> = {},
     TJsonData = null,
@@ -23,7 +28,7 @@ export const useStream = <
     url: string,
     options: StreamOptions<TSendBody> = {},
 ) => {
-    const id = useRef<string>(options.id ?? crypto.randomUUID());
+    const id = useRef<string>(options.id ?? generateId());
     const stream = useRef(resolveStream<TJsonData>(id.current));
     const headers = useRef<HeadersInit>(
         (() => {

--- a/packages/svelte/src/useStream.svelte.ts
+++ b/packages/svelte/src/useStream.svelte.ts
@@ -44,6 +44,11 @@ export type Stream<
  *
  * @see https://laravel.com/docs/responses#streamed-responses
  */
+const generateId = (): string =>
+    Array.from(crypto.getRandomValues(new Uint8Array(8)), (b) =>
+        b.toString(16).padStart(2, "0"),
+    ).join("");
+
 export const useStream = <
     TSendBody extends Record<string, any> = {},
     TJsonData = null,
@@ -52,7 +57,7 @@ export const useStream = <
     options: StreamOptions<TSendBody> = {},
 ): Stream<TJsonData, TSendBody> => {
     const getUrl = typeof url === "function" ? url : () => url;
-    const id = options.id ?? crypto.randomUUID();
+    const id = options.id ?? generateId();
     const initialStream = resolveStream<TJsonData>(id);
 
     const streamStore = writable<StreamState<TJsonData>>({

--- a/packages/vue/src/composables/useStream.ts
+++ b/packages/vue/src/composables/useStream.ts
@@ -25,6 +25,11 @@ import {
 } from "../streams/store";
 import { StreamMeta, StreamOptions } from "../types";
 
+const generateId = (): string =>
+    Array.from(crypto.getRandomValues(new Uint8Array(8)), (b) =>
+        b.toString(16).padStart(2, "0"),
+    ).join("");
+
 export const useStream = <
     TSendBody extends Record<string, any> = {},
     TJsonData = null,
@@ -42,7 +47,7 @@ export const useStream = <
     clearData: () => void;
 } => {
     const urlRef = toRef(url);
-    const id = options.id ?? crypto.randomUUID();
+    const id = options.id ?? generateId();
     const stream = ref<StreamMeta<TJsonData>>(resolveStream<TJsonData>(id));
     const headers = (() => {
         const headers: HeadersInit = {


### PR DESCRIPTION
`crypto.randomUUID()` is only available in secure contexts (HTTPS), so it would throw in plain HTTP. Switched to `crypto.getRandomValues()` which works everywhere and produces a random hex string that's more than sufficient for uniqueness.
