### PR TITLE
Fall back to the XSRF-TOKEN cookie when resolving CSRF

### DIFF
--- a/packages/react/src/hooks/use-stream.ts
+++ b/packages/react/src/hooks/use-stream.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { csrfHeaders } from "../streams/csrf";
 import {
     addCallbacks,
     onBeforeSend,
@@ -30,26 +31,11 @@ export const useStream = <
 ) => {
     const id = useRef<string>(options.id ?? generateId());
     const stream = useRef(resolveStream<TJsonData>(id.current));
-    const headers = useRef<HeadersInit>(
-        (() => {
-            const headers: HeadersInit = {
-                "Content-Type": "application/json",
-                "X-STREAM-ID": id.current,
-            };
-
-            const csrfToken =
-                options.csrfToken ??
-                document
-                    .querySelector('meta[name="csrf-token"]')
-                    ?.getAttribute("content");
-
-            if (csrfToken) {
-                headers["X-CSRF-TOKEN"] = csrfToken;
-            }
-
-            return headers;
-        })(),
-    );
+    const headers = useRef<HeadersInit>({
+        "Content-Type": "application/json",
+        "X-STREAM-ID": id.current,
+        ...csrfHeaders(options),
+    });
 
     const [data, setData] = useState<string>(stream.current.data);
     const [jsonData, setJsonData] = useState<TJsonData | null>(

--- a/packages/react/src/streams/csrf.ts
+++ b/packages/react/src/streams/csrf.ts
@@ -1,0 +1,46 @@
+export type CsrfHeaderOptions = {
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+};
+
+export const csrfHeaders = ({
+    csrfToken,
+    xsrfCookieName = "XSRF-TOKEN",
+    xsrfHeaderName = "X-XSRF-TOKEN",
+}: CsrfHeaderOptions = {}): Record<string, string> => {
+    if (csrfToken) {
+        return { "X-CSRF-TOKEN": csrfToken };
+    }
+
+    if (typeof document === "undefined") {
+        return {};
+    }
+
+    const meta = document
+        .querySelector('meta[name="csrf-token"]')
+        ?.getAttribute("content");
+
+    if (meta) {
+        return { "X-CSRF-TOKEN": meta };
+    }
+
+    // Laravel sets an XSRF-TOKEN cookie on every session response, so an
+    // application rendering no csrf-token meta tag can still post.
+    const prefix = `${xsrfCookieName}=`;
+
+    const cookie = document.cookie
+        .split(";")
+        .map((entry) => entry.trim())
+        .find((entry) => entry.startsWith(prefix));
+
+    if (!cookie) {
+        return {};
+    }
+
+    // Laravel encrypts the cookie and Symfony percent-encodes it on the way
+    // out, so the value has to be decoded before it goes back as a header.
+    return {
+        [xsrfHeaderName]: decodeURIComponent(cookie.slice(prefix.length)),
+    };
+};

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -20,6 +20,8 @@ export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     initialInput?: TSendBody;
     headers?: Record<string, string>;
     csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
     json?: boolean;
     credentials?: RequestCredentials;
     onResponse?: (response: Response) => void;

--- a/packages/react/tests/use-stream.test.ts
+++ b/packages/react/tests/use-stream.test.ts
@@ -402,6 +402,66 @@ describe("useStream", () => {
         expect(capturedHeaders.get("Content-Type")).toBe("application/json");
     });
 
+    it("should fall back to the XSRF-TOKEN cookie when there is no meta tag", async () => {
+        document.cookie = "XSRF-TOKEN=cookie%2Dtoken%3D";
+
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const { result } = renderHook(() => useStream(url));
+
+        await act(() => {
+            result.current.send({ test: "data" });
+        });
+
+        await waitFor(() => expect(result.current.isStreaming).toBe(true));
+        await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+        document.cookie = "XSRF-TOKEN=; max-age=0";
+
+        expect(capturedHeaders.get("X-XSRF-TOKEN")).toBe("cookie-token=");
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBeNull();
+    });
+
+    it("should prefer the meta tag over the XSRF-TOKEN cookie", async () => {
+        document.cookie = "XSRF-TOKEN=cookie-token";
+
+        const metaTag = document.createElement("meta");
+        metaTag.setAttribute("name", "csrf-token");
+        metaTag.setAttribute("content", "meta-token");
+        document.head.appendChild(metaTag);
+
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const { result } = renderHook(() => useStream(url));
+
+        await act(() => {
+            result.current.send({ test: "data" });
+        });
+
+        await waitFor(() => expect(result.current.isStreaming).toBe(true));
+        await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+        document.head.removeChild(metaTag);
+        document.cookie = "XSRF-TOKEN=; max-age=0";
+
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBe("meta-token");
+        expect(capturedHeaders.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
     it("will generate unique ids for streams", async () => {
         const { result } = renderHook(() => useStream(url));
         const { result: result2 } = renderHook(() => useStream(url));

--- a/packages/svelte/src/streams/csrf.ts
+++ b/packages/svelte/src/streams/csrf.ts
@@ -1,0 +1,46 @@
+export type CsrfHeaderOptions = {
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+};
+
+export const csrfHeaders = ({
+    csrfToken,
+    xsrfCookieName = "XSRF-TOKEN",
+    xsrfHeaderName = "X-XSRF-TOKEN",
+}: CsrfHeaderOptions = {}): Record<string, string> => {
+    if (csrfToken) {
+        return { "X-CSRF-TOKEN": csrfToken };
+    }
+
+    if (typeof document === "undefined") {
+        return {};
+    }
+
+    const meta = document
+        .querySelector('meta[name="csrf-token"]')
+        ?.getAttribute("content");
+
+    if (meta) {
+        return { "X-CSRF-TOKEN": meta };
+    }
+
+    // Laravel sets an XSRF-TOKEN cookie on every session response, so an
+    // application rendering no csrf-token meta tag can still post.
+    const prefix = `${xsrfCookieName}=`;
+
+    const cookie = document.cookie
+        .split(";")
+        .map((entry) => entry.trim())
+        .find((entry) => entry.startsWith(prefix));
+
+    if (!cookie) {
+        return {};
+    }
+
+    // Laravel encrypts the cookie and Symfony percent-encodes it on the way
+    // out, so the value has to be decoded before it goes back as a header.
+    return {
+        [xsrfHeaderName]: decodeURIComponent(cookie.slice(prefix.length)),
+    };
+};

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -24,6 +24,8 @@ export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     initialInput?: TSendBody;
     headers?: Record<string, string>;
     csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
     json?: boolean;
     credentials?: RequestCredentials;
     onResponse?: (response: Response) => void;

--- a/packages/svelte/src/useStream.svelte.ts
+++ b/packages/svelte/src/useStream.svelte.ts
@@ -1,4 +1,5 @@
 import { derived, get, writable } from "svelte/store";
+import { csrfHeaders } from "./streams/csrf";
 import {
     addCallbacks,
     onBeforeSend,
@@ -67,24 +68,11 @@ export const useStream = <
         isStreaming: initialStream.isStreaming,
     });
 
-    const headers = (() => {
-        const headers: HeadersInit = {
-            "Content-Type": "application/json",
-            "X-STREAM-ID": id,
-        };
-
-        const csrfToken =
-            options.csrfToken ??
-            document
-                .querySelector('meta[name="csrf-token"]')
-                ?.getAttribute("content");
-
-        if (csrfToken) {
-            headers["X-CSRF-TOKEN"] = csrfToken;
-        }
-
-        return headers;
-    })();
+    const headers: HeadersInit = {
+        "Content-Type": "application/json",
+        "X-STREAM-ID": id,
+        ...csrfHeaders(options),
+    };
 
     let stopListening: (() => void) | undefined;
     let removeCallbacks: (() => void) | undefined;

--- a/packages/svelte/tests/useStream.test.ts
+++ b/packages/svelte/tests/useStream.test.ts
@@ -210,6 +210,64 @@ describe("useStream", () => {
         expect(state(result).data).toBe("chunk1chunk2");
     });
 
+    it("falls back to the XSRF-TOKEN cookie when there is no meta tag", async () => {
+        document.cookie = "XSRF-TOKEN=cookie%2Dtoken%3D";
+
+        let capturedHeaders: Headers | undefined;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const result = useStream(url);
+        await Promise.resolve();
+
+        result.send({ test: "data" });
+
+        await vi.waitFor(() => expect(state(result).isStreaming).toBe(true));
+        await vi.waitFor(() => expect(state(result).isStreaming).toBe(false));
+
+        document.cookie = "XSRF-TOKEN=; max-age=0";
+
+        expect(capturedHeaders?.get("X-XSRF-TOKEN")).toBe("cookie-token=");
+        expect(capturedHeaders?.get("X-CSRF-TOKEN")).toBeNull();
+    });
+
+    it("prefers the meta tag over the XSRF-TOKEN cookie", async () => {
+        document.cookie = "XSRF-TOKEN=cookie-token";
+
+        const metaTag = document.createElement("meta");
+        metaTag.setAttribute("name", "csrf-token");
+        metaTag.setAttribute("content", "meta-token");
+        document.head.appendChild(metaTag);
+
+        let capturedHeaders: Headers | undefined;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const result = useStream(url);
+        await Promise.resolve();
+
+        result.send({ test: "data" });
+
+        await vi.waitFor(() => expect(state(result).isStreaming).toBe(true));
+        await vi.waitFor(() => expect(state(result).isStreaming).toBe(false));
+
+        document.head.removeChild(metaTag);
+        document.cookie = "XSRF-TOKEN=; max-age=0";
+
+        expect(capturedHeaders?.get("X-CSRF-TOKEN")).toBe("meta-token");
+        expect(capturedHeaders?.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
     it("triggers onData callback with chunks", async () => {
         const onData = vi.fn();
 

--- a/packages/vue/src/composables/useStream.ts
+++ b/packages/vue/src/composables/useStream.ts
@@ -8,6 +8,7 @@ import {
     toRef,
     watch,
 } from "vue";
+import { csrfHeaders } from "../streams/csrf";
 import {
     addCallbacks,
     onBeforeSend,
@@ -49,24 +50,11 @@ export const useStream = <
     const urlRef = toRef(url);
     const id = options.id ?? generateId();
     const stream = ref<StreamMeta<TJsonData>>(resolveStream<TJsonData>(id));
-    const headers = (() => {
-        const headers: HeadersInit = {
-            "Content-Type": "application/json",
-            "X-STREAM-ID": id,
-        };
-
-        const csrfToken =
-            options.csrfToken ??
-            document
-                .querySelector('meta[name="csrf-token"]')
-                ?.getAttribute("content");
-
-        if (csrfToken) {
-            headers["X-CSRF-TOKEN"] = csrfToken;
-        }
-
-        return headers;
-    })();
+    const headers: HeadersInit = {
+        "Content-Type": "application/json",
+        "X-STREAM-ID": id,
+        ...csrfHeaders(options),
+    };
 
     const data = ref(stream.value.data);
     const jsonData = ref(stream.value.jsonData);

--- a/packages/vue/src/streams/csrf.ts
+++ b/packages/vue/src/streams/csrf.ts
@@ -1,0 +1,46 @@
+export type CsrfHeaderOptions = {
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+};
+
+export const csrfHeaders = ({
+    csrfToken,
+    xsrfCookieName = "XSRF-TOKEN",
+    xsrfHeaderName = "X-XSRF-TOKEN",
+}: CsrfHeaderOptions = {}): Record<string, string> => {
+    if (csrfToken) {
+        return { "X-CSRF-TOKEN": csrfToken };
+    }
+
+    if (typeof document === "undefined") {
+        return {};
+    }
+
+    const meta = document
+        .querySelector('meta[name="csrf-token"]')
+        ?.getAttribute("content");
+
+    if (meta) {
+        return { "X-CSRF-TOKEN": meta };
+    }
+
+    // Laravel sets an XSRF-TOKEN cookie on every session response, so an
+    // application rendering no csrf-token meta tag can still post.
+    const prefix = `${xsrfCookieName}=`;
+
+    const cookie = document.cookie
+        .split(";")
+        .map((entry) => entry.trim())
+        .find((entry) => entry.startsWith(prefix));
+
+    if (!cookie) {
+        return {};
+    }
+
+    // Laravel encrypts the cookie and Symfony percent-encodes it on the way
+    // out, so the value has to be decoded before it goes back as a header.
+    return {
+        [xsrfHeaderName]: decodeURIComponent(cookie.slice(prefix.length)),
+    };
+};

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -22,6 +22,8 @@ export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     initialInput?: TSendBody;
     headers?: Record<string, string>;
     csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
     json?: boolean;
     credentials?: RequestCredentials;
     onResponse?: (response: Response) => void;

--- a/packages/vue/tests/useStream.test.ts
+++ b/packages/vue/tests/useStream.test.ts
@@ -305,6 +305,92 @@ describe("useStream", () => {
         expect(capturedHeaders.get("Content-Type")).toBe("application/json");
     });
 
+    it("falls back to the XSRF-TOKEN cookie when there is no meta tag", async () => {
+        document.cookie = "XSRF-TOKEN=cookie%2Dtoken%3D";
+
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const [result] = withSetup(() => useStream(url));
+
+        result.send({ test: "data" });
+
+        await vi.waitFor(() => expect(result.isStreaming.value).toBe(true));
+        await vi.waitFor(() => expect(result.isStreaming.value).toBe(false));
+
+        document.cookie = "XSRF-TOKEN=; max-age=0";
+
+        expect(capturedHeaders.get("X-XSRF-TOKEN")).toBe("cookie-token=");
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBeNull();
+    });
+
+    it("prefers the meta tag over the XSRF-TOKEN cookie", async () => {
+        document.cookie = "XSRF-TOKEN=cookie-token";
+
+        const metaTag = document.createElement("meta");
+        metaTag.setAttribute("name", "csrf-token");
+        metaTag.setAttribute("content", "meta-token");
+        document.head.appendChild(metaTag);
+
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const [result] = withSetup(() => useStream(url));
+
+        result.send({ test: "data" });
+
+        await vi.waitFor(() => expect(result.isStreaming.value).toBe(true));
+        await vi.waitFor(() => expect(result.isStreaming.value).toBe(false));
+
+        document.head.removeChild(metaTag);
+        document.cookie = "XSRF-TOKEN=; max-age=0";
+
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBe("meta-token");
+        expect(capturedHeaders.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
+    it("honors a renamed XSRF cookie and header", async () => {
+        document.cookie = "MY-TOKEN=renamed";
+
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedHeaders = request.headers;
+                return response();
+            }),
+        );
+
+        const [result] = withSetup(() =>
+            useStream(url, {
+                xsrfCookieName: "MY-TOKEN",
+                xsrfHeaderName: "X-MY-TOKEN",
+            }),
+        );
+
+        result.send({ test: "data" });
+
+        await vi.waitFor(() => expect(result.isStreaming.value).toBe(true));
+        await vi.waitFor(() => expect(result.isStreaming.value).toBe(false));
+
+        document.cookie = "MY-TOKEN=; max-age=0";
+
+        expect(capturedHeaders.get("X-MY-TOKEN")).toBe("renamed");
+        expect(capturedHeaders.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
     it("generates unique ids for streams", () => {
         const [result1] = withSetup(() => useStream(url));
         const [result2] = withSetup(() => useStream(url));


### PR DESCRIPTION
The stream hooks resolve a CSRF token from the `csrfToken` option or a `csrf-token` meta tag. For apps that render no meta tag, posting to a stream is rejected unless the token is passed through manually.

As Laravel sets an `XSRF-TOKEN` cookie, the hooks now fall back to reading that cookie and sending it as an `X-XSRF-TOKEN` header. The resolution order is otherwise unchanged, so nothing about an existing application's behavior moves: the `csrfToken` option first, then the meta tag, and only then the cookie.

The cookie and header names may be customized, using the same option names Inertia and Axios already use:

```vue
<script setup lang="ts">
import { useStream } from "@laravel/stream-vue";

const { data, send } = useStream("/chat", {
    xsrfCookieName: "XSRF-TOKEN",
    xsrfHeaderName: "X-XSRF-TOKEN",
});
</script>
```