### PR TITLE
Add `useJsonEventStream` hook

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -301,7 +301,7 @@ function App() {
 
 The `useJsonEventStream` hook allows you to POST a request body and consume the [Server-Sent Events (SSE)](https://laravel.com/docs/responses#event-streams) that come back, parsing each event as JSON as it arrives.
 
-Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this hook sends a `POST` request when you call `send` — so you may pass a body and your CSRF token along with it:
+Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this hook sends a request when you call `send`, so you may pass a body and your CSRF token along with it. All requests are sent as JSON `POST` requests:
 
 ```tsx
 import { useJsonEventStream } from "@laravel/stream-react";
@@ -316,7 +316,7 @@ function App() {
         <div>
             {events.map((event) => (
                 <div>
-                    {event.step} — {event.percent}%
+                    {event.step}: {event.percent}%
                 </div>
             ))}
             {isFetching && <div>Connecting...</div>}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -297,6 +297,128 @@ function App() {
 }
 ```
 
+## JSON Event Streams
+
+The `useJsonEventStream` hook allows you to POST a request body and consume the [Server-Sent Events (SSE)](https://laravel.com/docs/responses#event-streams) that come back, parsing each event as JSON as it arrives.
+
+Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this hook sends a `POST` request when you call `send` — so you may pass a body and your CSRF token along with it:
+
+```tsx
+import { useJsonEventStream } from "@laravel/stream-react";
+
+type Deployment = { step: string; percent: number };
+
+function App() {
+    const { events, isFetching, isStreaming, send } =
+        useJsonEventStream<Deployment>("/deploy");
+
+    return (
+        <div>
+            {events.map((event) => (
+                <div>
+                    {event.step} — {event.percent}%
+                </div>
+            ))}
+            {isFetching && <div>Connecting...</div>}
+            {isStreaming && <div>Deploying...</div>}
+            <button onClick={() => send({ environment: "production" })}>
+                Deploy
+            </button>
+        </div>
+    );
+}
+```
+
+Each event is passed to the `onEvent` callback as it is received, so you may fold it into your own state instead of using the `events` array:
+
+```tsx
+import { useJsonEventStream } from "@laravel/stream-react";
+import { useState } from "react";
+
+function App() {
+    const [percent, setPercent] = useState(0);
+
+    const { send } = useJsonEventStream<Deployment>("/deploy", {
+        onEvent: (event) => setPercent(event.percent),
+    });
+
+    return <div>{percent}%</div>;
+}
+```
+
+The second argument given to `useJsonEventStream` is an options object that you may use to customize the stream consumption behavior:
+
+```ts
+type JsonEventStreamOptions = {
+    initialInput?: Record<string, any>;
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    onEvent?: (event: TEvent) => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onCancel?: () => void;
+    onFinish?: () => void;
+    onError?: (error: Error) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+```
+
+`eventName` limits the events you receive to those sent under the given name. By default every event is received, including those your server sends without a name.
+
+`endSignal` is the event data that ends the stream, matching the `</stream>` that Laravel's `eventStream` method sends by default.
+
+`onParseError` is called when an event arrives that is not valid JSON. The event is skipped and the stream continues.
+
+`onError` is called when the request fails. A response that never became a stream is passed to the callback as a `StreamResponseError`, which carries the `status` and the raw `body` so you may read your server's error:
+
+```tsx
+import { StreamResponseError, useJsonEventStream } from "@laravel/stream-react";
+
+function App() {
+    const { send } = useJsonEventStream("/deploy", {
+        onError: (error) => {
+            if (error instanceof StreamResponseError && error.status === 422) {
+                const { errors } = JSON.parse(error.body);
+            }
+        },
+    });
+}
+```
+
+You may cancel an in-flight stream using the returned `cancel` function, and the `clearEvents` function may be used to clear the events that have been received so far:
+
+```tsx
+import { useJsonEventStream } from "@laravel/stream-react";
+
+function App() {
+    const { events, cancel, clearEvents } = useJsonEventStream("/deploy");
+}
+```
+
+### Streaming Without State
+
+If you are folding events into state you already own, the `streamJsonEvents` function does the same work without any of the hook's state:
+
+```ts
+import { streamJsonEvents } from "@laravel/stream-react";
+
+const controller = new AbortController();
+
+await streamJsonEvents<Deployment>({
+    url: "/deploy",
+    body: { environment: "production" },
+    signal: controller.signal,
+    onEvent: (event) => {
+        //
+    },
+});
+```
+
 ## License
 
 Laravel Stream is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/packages/react/src/hooks/use-json-event-stream.ts
+++ b/packages/react/src/hooks/use-json-event-stream.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { streamJsonEvents } from "../streams/jsonEvents";
+import { JsonEventStreamOptions, JsonEventStreamResult } from "../types";
+
+/**
+ * Hook for posting a body and reading a stream of JSON events back
+ *
+ * @param url - The URL to post to
+ * @param options - Options for the stream
+ *
+ * @link https://laravel.com/docs/responses#event-streams
+ *
+ * @returns Result object containing the received events, send, and cancel functions
+ */
+export const useJsonEventStream = <
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+>(
+    url: string,
+    options: JsonEventStreamOptions<TEvent, TSendBody> = {},
+): JsonEventStreamResult<TEvent, TSendBody> => {
+    const controllerRef = useRef<AbortController | null>(null);
+    const optionsRef = useRef(options);
+
+    optionsRef.current = options;
+
+    const [events, setEvents] = useState<TEvent[]>([]);
+    const [isFetching, setIsFetching] = useState(false);
+    const [isStreaming, setIsStreaming] = useState(false);
+
+    const clearEvents = useCallback(() => {
+        setEvents([]);
+    }, []);
+
+    const cancel = useCallback(() => {
+        if (controllerRef.current === null) {
+            return;
+        }
+
+        controllerRef.current.abort();
+        controllerRef.current = null;
+
+        setIsFetching(false);
+        setIsStreaming(false);
+
+        optionsRef.current.onCancel?.();
+    }, []);
+
+    const send = useCallback(
+        async (body?: TSendBody) => {
+            const current = optionsRef.current;
+
+            cancel();
+
+            const pending = new AbortController();
+
+            const finish = () => {
+                controllerRef.current = null;
+
+                setIsFetching(false);
+                setIsStreaming(false);
+
+                current.onFinish?.();
+            };
+
+            try {
+                const sent = await streamJsonEvents<TEvent, TSendBody>({
+                    url,
+                    body,
+                    signal: pending.signal,
+                    headers: current.headers,
+                    csrfToken: current.csrfToken,
+                    xsrfCookieName: current.xsrfCookieName,
+                    xsrfHeaderName: current.xsrfHeaderName,
+                    credentials: current.credentials,
+                    eventName: current.eventName,
+                    endSignal: current.endSignal,
+                    onBeforeSend: current.onBeforeSend,
+                    onParseError: current.onParseError,
+                    onSend: () => {
+                        setEvents([]);
+
+                        controllerRef.current = pending;
+
+                        setIsFetching(true);
+                    },
+                    onResponse: (response) => {
+                        setIsFetching(false);
+                        setIsStreaming(true);
+
+                        current.onResponse?.(response);
+                    },
+                    onEvent: (event) => {
+                        setEvents((previous) => [...previous, event]);
+
+                        current.onEvent?.(event);
+                    },
+                });
+
+                if (sent) {
+                    finish();
+                }
+            } catch (error) {
+                if ((error as Error).name === "AbortError") {
+                    return;
+                }
+
+                setIsFetching(false);
+                setIsStreaming(false);
+
+                current.onError?.(error as Error);
+
+                finish();
+            }
+        },
+        [url, cancel],
+    );
+
+    useEffect(() => {
+        window.addEventListener("beforeunload", cancel);
+
+        return () => {
+            window.removeEventListener("beforeunload", cancel);
+
+            cancel();
+        };
+    }, [cancel]);
+
+    useEffect(() => {
+        if (optionsRef.current.initialInput) {
+            void send(optionsRef.current.initialInput);
+        }
+        // Fires once on mount, like useStream's initial request...
+    }, []);
+
+    return {
+        events,
+        isFetching,
+        isStreaming,
+        send,
+        cancel,
+        clearEvents,
+    };
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,9 @@
 export { useEventStream } from "./hooks/use-event-stream";
+export { useJsonEventStream } from "./hooks/use-json-event-stream";
+export { csrfHeaders, type CsrfHeaderOptions } from "./streams/csrf";
+export {
+    streamJsonEvents,
+    StreamResponseError,
+    type JsonEventStreamRequest,
+} from "./streams/jsonEvents";
 export { useJsonStream, useStream } from "./hooks/use-stream";

--- a/packages/react/src/streams/events.ts
+++ b/packages/react/src/streams/events.ts
@@ -1,0 +1,126 @@
+export type StreamFrame = {
+    event: string | null;
+    id: string | null;
+    data: string;
+};
+
+export type FrameHandler = (frame: StreamFrame) => boolean;
+
+export const readEventStream = async (
+    body: ReadableStream<Uint8Array>,
+    onFrame: FrameHandler,
+): Promise<void> => {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    let carriageReturn = "";
+
+    // Belongs to the stream rather than the frame: it holds its value until
+    // the server sets it again, and an id counts even on a frame that
+    // dispatches nothing.
+    let lastEventId: string | null = null;
+
+    const dispatchFrame = (frame: string): boolean => {
+        const fields = parseFields(frame);
+
+        if (fields.id !== undefined) {
+            lastEventId = fields.id;
+        }
+
+        if (fields.data === null) {
+            return true;
+        }
+
+        return onFrame({
+            event: fields.event,
+            id: lastEventId,
+            data: fields.data,
+        });
+    };
+
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+
+            if (done) {
+                break;
+            }
+
+            buffer += carriageReturn + decoder.decode(value, { stream: true });
+            carriageReturn = "";
+
+            // Held back so a CRLF split across two reads is not turned
+            // into two line breaks, halving one frame.
+            if (buffer.endsWith("\r")) {
+                buffer = buffer.slice(0, -1);
+                carriageReturn = "\r";
+            }
+
+            buffer = buffer.replace(/\r\n?/g, "\n");
+
+            let boundary = buffer.indexOf("\n\n");
+
+            while (boundary !== -1) {
+                const frame = buffer.slice(0, boundary);
+
+                buffer = buffer.slice(boundary + 2);
+
+                if (!dispatchFrame(frame)) {
+                    // Not awaited: a source mid-write may not settle its
+                    // cancel until it finishes.
+                    void reader.cancel().catch(() => undefined);
+
+                    return;
+                }
+
+                boundary = buffer.indexOf("\n\n");
+            }
+        }
+
+        // Anything left never reached its blank line, and an incomplete
+        // frame is discarded at end of file.
+    } finally {
+        reader.releaseLock();
+    }
+};
+
+type ParsedFields = {
+    event: string | null;
+    id: string | undefined;
+    data: string | null;
+};
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/server-sent-events.html
+ */
+const parseFields = (frame: string): ParsedFields => {
+    const data: string[] = [];
+
+    let event: string | null = null;
+    let id: string | undefined;
+
+    for (const line of frame.split("\n")) {
+        if (line === "" || line.startsWith(":")) {
+            continue;
+        }
+
+        const colon = line.indexOf(":");
+        const field = colon === -1 ? line : line.slice(0, colon);
+        const value =
+            colon === -1 ? "" : stripLeadingSpace(line.slice(colon + 1));
+
+        if (field === "data") {
+            data.push(value);
+        } else if (field === "event") {
+            event = value;
+        } else if (field === "id" && !value.includes("\u0000")) {
+            id = value;
+        }
+    }
+
+    return { event, id, data: data.length === 0 ? null : data.join("\n") };
+};
+
+const stripLeadingSpace = (value: string): string =>
+    value.startsWith(" ") ? value.slice(1) : value;

--- a/packages/react/src/streams/jsonEvents.ts
+++ b/packages/react/src/streams/jsonEvents.ts
@@ -1,0 +1,161 @@
+import { csrfHeaders } from "./csrf";
+import { readEventStream } from "./events";
+
+export class StreamResponseError extends Error {
+    constructor(
+        public readonly response: Response,
+        public readonly body: string,
+    ) {
+        super(
+            body || `The stream request failed with status ${response.status}.`,
+        );
+
+        this.name = "StreamResponseError";
+    }
+
+    get status(): number {
+        return this.response.status;
+    }
+}
+
+export type JsonEventStreamRequest<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    url: string;
+    body?: TSendBody;
+    signal: AbortSignal;
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    onEvent: (event: TEvent) => void;
+    onSend?: () => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+
+/**
+ * Post a body and read a stream of JSON events back
+ *
+ * The primitive `useJsonEventStream` is built on, for events folded into state
+ * the caller already owns rather than collected into an array.
+ *
+ * @param request - The URL, body, signal and callbacks for the stream
+ *
+ * @link https://laravel.com/docs/responses#event-streams
+ *
+ * @returns False when onBeforeSend refused the request, otherwise true
+ */
+export const streamJsonEvents = async <
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+>({
+    url,
+    body,
+    signal,
+    headers,
+    csrfToken,
+    xsrfCookieName,
+    xsrfHeaderName,
+    credentials,
+    eventName,
+    endSignal = "</stream>",
+    onEvent,
+    onSend,
+    onResponse,
+    onParseError,
+    onBeforeSend,
+}: JsonEventStreamRequest<TEvent, TSendBody>): Promise<boolean> => {
+    const request: RequestInit = {
+        method: "POST",
+        signal,
+        credentials: credentials ?? "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            ...csrfHeaders({ csrfToken, xsrfCookieName, xsrfHeaderName }),
+            ...(headers ?? {}),
+        },
+        body: JSON.stringify(body ?? {}),
+    };
+
+    const modified = onBeforeSend?.(request);
+
+    if (modified === false) {
+        return false;
+    }
+
+    onSend?.();
+
+    const response = await fetch(
+        url,
+        typeof modified === "object" && modified !== null ? modified : request,
+    );
+
+    if (!response.ok) {
+        throw new StreamResponseError(response, await response.text());
+    }
+
+    if (!response.body) {
+        throw new Error("ReadableStream not yet supported in this browser.");
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+
+    if (!contentType.includes("text/event-stream")) {
+        throw new Error(
+            `Expected a text/event-stream response, received "${contentType}".`,
+        );
+    }
+
+    onResponse?.(response);
+
+    const eventNames = eventName === undefined ? null : [eventName].flat();
+
+    await readEventStream(response.body, (frame) => {
+        if (signal.aborted) {
+            return false;
+        }
+
+        // Before the event name filter, so a terminator sent under a
+        // different name still ends the stream.
+        if (frame.data === endSignal) {
+            return false;
+        }
+
+        // A frame with no event field is of type "message".
+        if (
+            eventNames !== null &&
+            !eventNames.includes(frame.event ?? "message")
+        ) {
+            return true;
+        }
+
+        let event: TEvent;
+
+        try {
+            event = JSON.parse(frame.data) as TEvent;
+        } catch (error) {
+            onParseError?.(error as Error, frame.data);
+
+            return true;
+        }
+
+        // Outside the try, so a throw from the caller is not mistaken for
+        // a malformed frame.
+        onEvent(event);
+
+        return true;
+    });
+
+    if (signal.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    return true;
+};

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -15,6 +15,39 @@ export type EventStreamResult = {
     clearMessage: () => void;
 };
 
+export type JsonEventStreamOptions<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    initialInput?: TSendBody;
+    onEvent?: (event: TEvent) => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onCancel?: () => void;
+    onFinish?: () => void;
+    onError?: (error: Error) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+
+export type JsonEventStreamResult<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    events: TEvent[];
+    isFetching: boolean;
+    isStreaming: boolean;
+    send: (body?: TSendBody) => Promise<void>;
+    cancel: () => void;
+    clearEvents: () => void;
+};
+
 export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     id?: string;
     initialInput?: TSendBody;

--- a/packages/react/tests/readEventStream.test.ts
+++ b/packages/react/tests/readEventStream.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { readEventStream, StreamFrame } from "../src/streams/events";
+
+const bodyOf = (
+    chunks: string[],
+    cancel?: () => void,
+): ReadableStream<Uint8Array> =>
+    new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks) {
+                controller.enqueue(new TextEncoder().encode(chunk));
+            }
+
+            controller.close();
+        },
+        cancel,
+    });
+
+const framesOf = async (chunks: string[]): Promise<StreamFrame[]> => {
+    const frames: StreamFrame[] = [];
+
+    await readEventStream(bodyOf(chunks), (frame) => {
+        frames.push(frame);
+
+        return true;
+    });
+
+    return frames;
+};
+
+describe("readEventStream", () => {
+    it("discards a frame that never reached its blank line", async () => {
+        expect(await framesOf(["data: one\n\ndata: trunc"])).toEqual([
+            { event: null, id: null, data: "one" },
+        ]);
+    });
+
+    it("cancels the body when the handler stops reading", async () => {
+        const cancel = vi.fn();
+
+        // Left open, the way a server still writing after a terminator would
+        // leave it. Without the cancel it streams into a body nobody reads...
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+            },
+            cancel,
+        });
+
+        await readEventStream(body, () => false);
+
+        expect(cancel).toHaveBeenCalled();
+    });
+
+    it("reads the fields of a frame", async () => {
+        expect(
+            await framesOf(["id: 7\nevent: update\ndata: hello\n\n"]),
+        ).toEqual([{ event: "update", id: "7", data: "hello" }]);
+    });
+
+    it("joins multi-line data and skips comments and blank lines", async () => {
+        expect(await framesOf([": ping\ndata: one\ndata: two\n\n"])).toEqual([
+            { event: null, id: null, data: "one\ntwo" },
+        ]);
+    });
+
+    it("strips only the single space after a field's colon", async () => {
+        expect(await framesOf(["data:  padded \n\n"])).toEqual([
+            { event: null, id: null, data: " padded " },
+        ]);
+    });
+
+    it("reads a frame terminated with CRLF", async () => {
+        expect(await framesOf(["event: update\r\ndata: one\r\n\r\n"])).toEqual([
+            { event: "update", id: null, data: "one" },
+        ]);
+    });
+
+    it("reads a CRLF pair split across two chunks", async () => {
+        expect(
+            await framesOf(["data: one\r", "\n\r\ndata: two\r\n\r\n"]),
+        ).toEqual([
+            { event: null, id: null, data: "one" },
+            { event: null, id: null, data: "two" },
+        ]);
+    });
+
+    it("carries the last event id forward to later frames", async () => {
+        // The last event ID buffer belongs to the stream and is not reset when
+        // an event is dispatched...
+        expect(await framesOf(["id: 7\ndata: one\n\ndata: two\n\n"])).toEqual([
+            { event: null, id: "7", data: "one" },
+            { event: null, id: "7", data: "two" },
+        ]);
+    });
+
+    it("takes the id from a frame that dispatches nothing", async () => {
+        // The id is recorded before the frame is dropped for carrying no data...
+        expect(await framesOf(["id: 7\n\ndata: one\n\n"])).toEqual([
+            { event: null, id: "7", data: "one" },
+        ]);
+    });
+
+    it("ignores an id containing a NULL", async () => {
+        expect(
+            await framesOf(["id: 7\n\nid: a\u0000b\ndata: one\n\n"]),
+        ).toEqual([{ event: null, id: "7", data: "one" }]);
+    });
+
+    it("skips a frame that carries no data lines", async () => {
+        expect(await framesOf(["event: ping\n\ndata: one\n\n"])).toEqual([
+            { event: null, id: null, data: "one" },
+        ]);
+    });
+});

--- a/packages/react/tests/streamJsonEvents.test.ts
+++ b/packages/react/tests/streamJsonEvents.test.ts
@@ -1,0 +1,297 @@
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+import {
+    StreamResponseError,
+    streamJsonEvents,
+} from "../src/streams/jsonEvents";
+
+type TestEvent = { type: string };
+
+describe("streamJsonEvents", () => {
+    const url = "/chat";
+
+    const streamOf = (chunks: string[], duration = 5) =>
+        new HttpResponse(
+            new ReadableStream({
+                async start(controller) {
+                    for (const chunk of chunks) {
+                        await delay(duration);
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+
+                    controller.close();
+                },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+    const server = setupServer();
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("hands each event to the caller without collecting them", async () => {
+        const seen: TestEvent[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const sent = await streamJsonEvents<TestEvent>({
+            url,
+            body: { message: "Hello" },
+            signal: new AbortController().signal,
+            onEvent: (event) => seen.push(event),
+        });
+
+        expect(sent).toBe(true);
+        expect(seen).toEqual([{ type: "one" }, { type: "two" }]);
+    });
+
+    it("resolves false when onBeforeSend refuses the request", async () => {
+        const handler = vi.fn(() => streamOf(["data: </stream>\n\n"]));
+
+        server.use(http.post(url, handler));
+
+        const sent = await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => false,
+            onEvent: () => undefined,
+        });
+
+        expect(sent).toBe(false);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("calls onSend once the request is committed", async () => {
+        const order: string[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => {
+                order.push("before");
+            },
+            onSend: () => order.push("send"),
+            onEvent: () => order.push("event"),
+        });
+
+        expect(order).toEqual(["before", "send", "event"]);
+    });
+
+    it("does not call onSend when onBeforeSend refuses", async () => {
+        const onSend = vi.fn();
+
+        server.use(http.post(url, () => streamOf(["data: </stream>\n\n"])));
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => false,
+            onSend,
+            onEvent: () => undefined,
+        });
+
+        expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("honors a renamed XSRF cookie and header", async () => {
+        document.cookie = "MY-TOKEN=renamed";
+
+        let capturedHeaders: Headers | undefined;
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf(["data: </stream>\n\n"]);
+            }),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            xsrfCookieName: "MY-TOKEN",
+            xsrfHeaderName: "X-MY-TOKEN",
+            onEvent: () => undefined,
+        });
+
+        document.cookie = "MY-TOKEN=; max-age=0";
+
+        expect(capturedHeaders?.get("X-MY-TOKEN")).toBe("renamed");
+        expect(capturedHeaders?.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
+    it("throws the body of a non-OK response", async () => {
+        server.use(
+            http.post(url, () => HttpResponse.text("Boom", { status: 422 })),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => undefined,
+            }),
+        ).rejects.toThrow("Boom");
+    });
+
+    it("carries the failed response on the thrown error", async () => {
+        server.use(
+            http.post(url, () =>
+                HttpResponse.json({ message: "Nope" }, { status: 422 }),
+            ),
+        );
+
+        const error = await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onEvent: () => undefined,
+        }).catch((thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(StreamResponseError);
+        expect((error as StreamResponseError).status).toBe(422);
+        expect(JSON.parse((error as StreamResponseError).body)).toEqual({
+            message: "Nope",
+        });
+    });
+
+    it("throws when the response is not an event stream", async () => {
+        // A login page or proxy error answering 200 with HTML would otherwise
+        // finish reporting nothing at all...
+        server.use(
+            http.post(url, () =>
+                HttpResponse.html("<html>Log in</html>", { status: 200 }),
+            ),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => undefined,
+            }),
+        ).rejects.toThrow(/text\/event-stream/);
+    });
+
+    it("reports a malformed frame through onParseError and keeps reading", async () => {
+        const onParseError = vi.fn();
+        const seen: TestEvent[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    "data: not json\n\n",
+                    'data: {"type":"after"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onParseError,
+            onEvent: (event) => seen.push(event),
+        });
+
+        expect(onParseError).toHaveBeenCalledTimes(1);
+        expect(onParseError.mock.calls[0][1]).toBe("not json");
+        expect(seen).toEqual([{ type: "after" }]);
+    });
+
+    it("stops promptly when the signal aborts before any frame arrives", async () => {
+        const controller = new AbortController();
+        const onEvent = vi.fn();
+
+        // fetch errors the response body when its signal aborts, so the
+        // pending read rejects rather than waiting for a chunk...
+        server.use(
+            http.post(url, () => streamOf(['data: {"type":"one"}\n\n'], 5_000)),
+        );
+
+        const promise = streamJsonEvents<TestEvent>({
+            url,
+            signal: controller.signal,
+            onEvent,
+        });
+
+        controller.abort();
+
+        await expect(promise).rejects.toThrow();
+
+        expect(onEvent).not.toHaveBeenCalled();
+    }, 2_000);
+
+    it("stops reading when the signal aborts", async () => {
+        const seen: TestEvent[] = [];
+        const controller = new AbortController();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(
+                    [
+                        'data: {"type":"one"}\n\n',
+                        'data: {"type":"two"}\n\n',
+                        "data: </stream>\n\n",
+                    ],
+                    30,
+                ),
+            ),
+        );
+
+        const promise = streamJsonEvents<TestEvent>({
+            url,
+            signal: controller.signal,
+            onEvent: (event) => {
+                seen.push(event);
+                controller.abort();
+            },
+        });
+
+        await expect(promise).rejects.toThrow();
+
+        expect(seen).toEqual([{ type: "one" }]);
+    });
+
+    it("does not treat a throw from onEvent as a malformed frame", async () => {
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => {
+                    throw new Error("caller exploded");
+                },
+            }),
+        ).rejects.toThrow("caller exploded");
+    });
+});

--- a/packages/react/tests/use-json-event-stream.test.ts
+++ b/packages/react/tests/use-json-event-stream.test.ts
@@ -1,0 +1,553 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+import { useJsonEventStream } from "../src/hooks/use-json-event-stream";
+
+type TestEvent = { type: string };
+
+describe("useJsonEventStream", () => {
+    const url = "/chat";
+
+    const streamOf = (chunks: string[], duration = 5) =>
+        new HttpResponse(
+            new ReadableStream({
+                async start(controller) {
+                    for (const chunk of chunks) {
+                        await delay(duration);
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+
+                    controller.close();
+                },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+    const server = setupServer();
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("should post a body and parse each frame as its own event", async () => {
+        const onFinish = vi.fn();
+        let capturedBody: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedBody = await request.json();
+
+                return streamOf([
+                    'data: {"type":"start"}\n\n',
+                    'data: {"type":"delta"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send({ message: "Hello" }));
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedBody).toEqual({ message: "Hello" });
+        expect(result.current.events).toEqual([
+            { type: "start" },
+            { type: "delta" },
+        ]);
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.isStreaming).toBe(false);
+    });
+
+    it("should read a stream shaped like Laravel's eventStream helper", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: update\ndata: {"type":"one"}\n\n',
+                    'event: update\ndata: {"type":"two"}\n\n',
+                    "event: update\ndata: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([
+            { type: "one" },
+            { type: "two" },
+        ]);
+    });
+
+    it("should only keep the named events when an event name is given", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: token\ndata: {"type":"kept"}\n\n',
+                    'event: ping\ndata: {"type":"dropped"}\n\n',
+                    'data: {"type":"unnamed"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, {
+                eventName: "token",
+                onFinish,
+            }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "kept" }]);
+    });
+
+    it("should join frames split across chunk boundaries", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"ty',
+                    'pe":"split"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "split" }]);
+    });
+
+    it("should read frames terminated with CRLF", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: update\r\ndata: {"type":"crlf"}\r\n\r\n',
+                    "data: </stream>\r\n\r\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "crlf" }]);
+    });
+
+    it("should read a CRLF pair split across two chunks", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\r',
+                    '\n\r\ndata: {"type":"two"}\r\n\r\n',
+                    "data: </stream>\r\n\r\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([
+            { type: "one" },
+            { type: "two" },
+        ]);
+    });
+
+    it("should join multi-line data and ignore comments", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    ': keep-alive\ndata: {"type":\ndata: "multiline"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "multiline" }]);
+    });
+
+    it("should accept a data field written without a space", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(['data:{"type":"tight"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "tight" }]);
+    });
+
+    it("should drop a malformed frame without ending the stream", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    "data: not json\n\n",
+                    'data: {"type":"after"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "after" }]);
+    });
+
+    it("should call onEvent as each frame arrives", async () => {
+        const onEvent = vi.fn();
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onEvent, onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(onEvent).toHaveBeenCalledTimes(2);
+        expect(onEvent).toHaveBeenNthCalledWith(1, { type: "one" });
+        expect(onEvent).toHaveBeenNthCalledWith(2, { type: "two" });
+    });
+
+    it("should stop reading at the end signal", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"before"}\n\n',
+                    "data: </stream>\n\n",
+                    'data: {"type":"after"}\n\n',
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "before" }]);
+    });
+
+    it("should honor a custom end signal", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"before"}\n\n',
+                    "data: [DONE]\n\n",
+                    'data: {"type":"after"}\n\n',
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, {
+                endSignal: "[DONE]",
+                onFinish,
+            }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([{ type: "before" }]);
+    });
+
+    it("should finish when the body closes without an end signal", async () => {
+        const onFinish = vi.fn();
+
+        // laravel/ai's AG-UI protocol sends no terminator frame, so the stream
+        // simply ends when the body does...
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                ]),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.current.events).toEqual([
+            { type: "one" },
+            { type: "two" },
+        ]);
+        expect(result.current.isStreaming).toBe(false);
+    });
+
+    it("should send the initial input on mount", async () => {
+        const onFinish = vi.fn();
+        let capturedBody: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedBody = await request.json();
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, {
+                initialInput: { message: "Hello" },
+                onFinish,
+            }),
+        );
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedBody).toEqual({ message: "Hello" });
+        expect(result.current.events).toEqual([{ type: "one" }]);
+    });
+
+    it("should use the request returned by onBeforeSend", async () => {
+        const onFinish = vi.fn();
+        let capturedHeaders: any;
+
+        const onBeforeSend = vi.fn((request: RequestInit) => ({
+            ...request,
+            headers: {
+                ...(request.headers as Record<string, string>),
+                "X-Custom-Header": "custom-value",
+            },
+        }));
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onBeforeSend, onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedHeaders.get("X-Custom-Header")).toBe("custom-value");
+        expect(result.current.events).toEqual([{ type: "one" }]);
+    });
+
+    it("should not send when onBeforeSend returns false", async () => {
+        const handler = vi.fn(() =>
+            streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+        );
+
+        server.use(http.post(url, handler));
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onBeforeSend: () => false }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.current.events).toEqual([]);
+    });
+
+    it("should report a non-OK response as an error", async () => {
+        const onError = vi.fn();
+
+        server.use(
+            http.post(url, () => HttpResponse.text("Boom", { status: 422 })),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onError }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onError).toHaveBeenCalled());
+
+        expect(onError.mock.calls[0][0].message).toBe("Boom");
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.isStreaming).toBe(false);
+    });
+
+    it("should cancel an in-flight stream", async () => {
+        const onCancel = vi.fn();
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(
+                    [
+                        'data: {"type":"one"}\n\n',
+                        'data: {"type":"two"}\n\n',
+                        "data: </stream>\n\n",
+                    ],
+                    30,
+                ),
+            ),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { onCancel, onFinish }),
+        );
+
+        act(() => {
+            result.current.send();
+        });
+
+        await waitFor(() => expect(result.current.events).toHaveLength(1));
+
+        act(() => {
+            result.current.cancel();
+        });
+
+        // A cancelled run must not also report itself finished...
+        await new Promise((resolve) => setTimeout(resolve, 80));
+
+        expect(onCancel).toHaveBeenCalled();
+        expect(onFinish).not.toHaveBeenCalled();
+        expect(result.current.isStreaming).toBe(false);
+        expect(result.current.events).toEqual([{ type: "one" }]);
+    });
+
+    it("should send the CSRF token and clear events on the next send", async () => {
+        const csrfToken = "test-csrf-token";
+        const onFinish = vi.fn();
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useJsonEventStream<TestEvent>(url, { csrfToken, onFinish }),
+        );
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalledTimes(1));
+
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBe(csrfToken);
+        expect(capturedHeaders.get("Accept")).toBe("text/event-stream");
+        expect(result.current.events).toHaveLength(1);
+
+        await act(() => result.current.send());
+
+        await waitFor(() => expect(onFinish).toHaveBeenCalledTimes(2));
+
+        expect(result.current.events).toEqual([{ type: "one" }]);
+    });
+});

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -296,6 +296,133 @@ The `clearMessage` function may be used to clear the message content that has be
 <div>{$eventStream.message}</div>
 ```
 
+## JSON Event Streams
+
+The `useJsonEventStream` function allows you to POST a request body and consume the [Server-Sent Events (SSE)](https://laravel.com/docs/responses#event-streams) that come back, parsing each event as JSON as it arrives.
+
+Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this function sends a `POST` request when you call `send` — so you may pass a body and your CSRF token along with it:
+
+```svelte
+<script lang="ts">
+    import { useJsonEventStream } from "@laravel/stream-svelte";
+
+    type Deployment = { step: string; percent: number };
+
+    const stream = useJsonEventStream<Deployment>("/deploy");
+</script>
+
+{#each $stream.events as event}
+    <div>{event.step} — {event.percent}%</div>
+{/each}
+
+{#if $stream.isFetching}
+    <div>Connecting...</div>
+{/if}
+
+{#if $stream.isStreaming}
+    <div>Deploying...</div>
+{/if}
+
+<button onclick={() => stream.send({ environment: "production" })}>
+    Deploy
+</button>
+```
+
+Each event is passed to the `onEvent` callback as it is received, so you may fold it into your own state instead of using the `events` array:
+
+```svelte
+<script lang="ts">
+    import { useJsonEventStream } from "@laravel/stream-svelte";
+
+    let percent = $state(0);
+
+    const stream = useJsonEventStream<Deployment>("/deploy", {
+        onEvent: (event) => (percent = event.percent),
+    });
+</script>
+
+<div>{percent}%</div>
+```
+
+The second argument given to `useJsonEventStream` is an options object that you may use to customize the stream consumption behavior:
+
+```ts
+type JsonEventStreamOptions = {
+    initialInput?: Record<string, any>;
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    onEvent?: (event: TEvent) => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onCancel?: () => void;
+    onFinish?: () => void;
+    onError?: (error: Error) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+```
+
+`eventName` limits the events you receive to those sent under the given name. By default every event is received, including those your server sends without a name.
+
+`endSignal` is the event data that ends the stream, matching the `</stream>` that Laravel's `eventStream` method sends by default.
+
+`onParseError` is called when an event arrives that is not valid JSON. The event is skipped and the stream continues.
+
+`onError` is called when the request fails. A response that never became a stream is passed to the callback as a `StreamResponseError`, which carries the `status` and the raw `body` so you may read your server's error:
+
+```svelte
+<script lang="ts">
+    import {
+        StreamResponseError,
+        useJsonEventStream,
+    } from "@laravel/stream-svelte";
+
+    const stream = useJsonEventStream("/deploy", {
+        onError: (error) => {
+            if (error instanceof StreamResponseError && error.status === 422) {
+                const { errors } = JSON.parse(error.body);
+            }
+        },
+    });
+</script>
+```
+
+You may cancel an in-flight stream using the returned `cancel` function, and the `clearEvents` function may be used to clear the events that have been received so far:
+
+```svelte
+<script lang="ts">
+    import { useJsonEventStream } from "@laravel/stream-svelte";
+
+    const stream = useJsonEventStream("/deploy");
+</script>
+
+<button onclick={() => stream.cancel()}>Cancel</button>
+<button onclick={() => stream.clearEvents()}>Clear</button>
+```
+
+### Streaming Without State
+
+If you are folding events into state you already own, the `streamJsonEvents` function does the same work without any of the store's reactivity:
+
+```ts
+import { streamJsonEvents } from "@laravel/stream-svelte";
+
+const controller = new AbortController();
+
+await streamJsonEvents<Deployment>({
+    url: "/deploy",
+    body: { environment: "production" },
+    signal: controller.signal,
+    onEvent: (event) => {
+        //
+    },
+});
+```
+
 ## License
 
 Laravel Stream is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -300,7 +300,7 @@ The `clearMessage` function may be used to clear the message content that has be
 
 The `useJsonEventStream` function allows you to POST a request body and consume the [Server-Sent Events (SSE)](https://laravel.com/docs/responses#event-streams) that come back, parsing each event as JSON as it arrives.
 
-Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this function sends a `POST` request when you call `send` — so you may pass a body and your CSRF token along with it:
+Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this function sends a request when you call `send`, so you may pass a body and your CSRF token along with it. All requests are sent as JSON `POST` requests:
 
 ```svelte
 <script lang="ts">
@@ -312,7 +312,7 @@ Unlike `useEventStream`, which opens a GET connection as soon as your component 
 </script>
 
 {#each $stream.events as event}
-    <div>{event.step} — {event.percent}%</div>
+    <div>{event.step}: {event.percent}%</div>
 {/each}
 
 {#if $stream.isFetching}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,5 +1,16 @@
 export { useEventStream } from "./useEventStream.svelte";
 export {
+    useJsonEventStream,
+    type JsonEventStream,
+    type JsonEventStreamState,
+} from "./useJsonEventStream.svelte";
+export { csrfHeaders, type CsrfHeaderOptions } from "./streams/csrf";
+export {
+    streamJsonEvents,
+    StreamResponseError,
+    type JsonEventStreamRequest,
+} from "./streams/jsonEvents";
+export {
     useJsonStream,
     useStream,
     type JsonStreamState,
@@ -10,6 +21,7 @@ export type {
     EventStreamOptions,
     EventStreamResult,
     EventStreamState,
+    JsonEventStreamOptions,
     StreamMeta,
     StreamOptions,
 } from "./types";

--- a/packages/svelte/src/streams/events.ts
+++ b/packages/svelte/src/streams/events.ts
@@ -1,0 +1,126 @@
+export type StreamFrame = {
+    event: string | null;
+    id: string | null;
+    data: string;
+};
+
+export type FrameHandler = (frame: StreamFrame) => boolean;
+
+export const readEventStream = async (
+    body: ReadableStream<Uint8Array>,
+    onFrame: FrameHandler,
+): Promise<void> => {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    let carriageReturn = "";
+
+    // Belongs to the stream rather than the frame: it holds its value until
+    // the server sets it again, and an id counts even on a frame that
+    // dispatches nothing.
+    let lastEventId: string | null = null;
+
+    const dispatchFrame = (frame: string): boolean => {
+        const fields = parseFields(frame);
+
+        if (fields.id !== undefined) {
+            lastEventId = fields.id;
+        }
+
+        if (fields.data === null) {
+            return true;
+        }
+
+        return onFrame({
+            event: fields.event,
+            id: lastEventId,
+            data: fields.data,
+        });
+    };
+
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+
+            if (done) {
+                break;
+            }
+
+            buffer += carriageReturn + decoder.decode(value, { stream: true });
+            carriageReturn = "";
+
+            // Held back so a CRLF split across two reads is not turned
+            // into two line breaks, halving one frame.
+            if (buffer.endsWith("\r")) {
+                buffer = buffer.slice(0, -1);
+                carriageReturn = "\r";
+            }
+
+            buffer = buffer.replace(/\r\n?/g, "\n");
+
+            let boundary = buffer.indexOf("\n\n");
+
+            while (boundary !== -1) {
+                const frame = buffer.slice(0, boundary);
+
+                buffer = buffer.slice(boundary + 2);
+
+                if (!dispatchFrame(frame)) {
+                    // Not awaited: a source mid-write may not settle its
+                    // cancel until it finishes.
+                    void reader.cancel().catch(() => undefined);
+
+                    return;
+                }
+
+                boundary = buffer.indexOf("\n\n");
+            }
+        }
+
+        // Anything left never reached its blank line, and an incomplete
+        // frame is discarded at end of file.
+    } finally {
+        reader.releaseLock();
+    }
+};
+
+type ParsedFields = {
+    event: string | null;
+    id: string | undefined;
+    data: string | null;
+};
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/server-sent-events.html
+ */
+const parseFields = (frame: string): ParsedFields => {
+    const data: string[] = [];
+
+    let event: string | null = null;
+    let id: string | undefined;
+
+    for (const line of frame.split("\n")) {
+        if (line === "" || line.startsWith(":")) {
+            continue;
+        }
+
+        const colon = line.indexOf(":");
+        const field = colon === -1 ? line : line.slice(0, colon);
+        const value =
+            colon === -1 ? "" : stripLeadingSpace(line.slice(colon + 1));
+
+        if (field === "data") {
+            data.push(value);
+        } else if (field === "event") {
+            event = value;
+        } else if (field === "id" && !value.includes("\u0000")) {
+            id = value;
+        }
+    }
+
+    return { event, id, data: data.length === 0 ? null : data.join("\n") };
+};
+
+const stripLeadingSpace = (value: string): string =>
+    value.startsWith(" ") ? value.slice(1) : value;

--- a/packages/svelte/src/streams/jsonEvents.ts
+++ b/packages/svelte/src/streams/jsonEvents.ts
@@ -1,0 +1,161 @@
+import { csrfHeaders } from "./csrf";
+import { readEventStream } from "./events";
+
+export class StreamResponseError extends Error {
+    constructor(
+        public readonly response: Response,
+        public readonly body: string,
+    ) {
+        super(
+            body || `The stream request failed with status ${response.status}.`,
+        );
+
+        this.name = "StreamResponseError";
+    }
+
+    get status(): number {
+        return this.response.status;
+    }
+}
+
+export type JsonEventStreamRequest<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    url: string;
+    body?: TSendBody;
+    signal: AbortSignal;
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    onEvent: (event: TEvent) => void;
+    onSend?: () => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+
+/**
+ * Post a body and read a stream of JSON events back
+ *
+ * The primitive `useJsonEventStream` is built on, for events folded into state
+ * the caller already owns rather than collected into an array.
+ *
+ * @param request - The URL, body, signal and callbacks for the stream
+ *
+ * @link https://laravel.com/docs/responses#event-streams
+ *
+ * @returns False when onBeforeSend refused the request, otherwise true
+ */
+export const streamJsonEvents = async <
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+>({
+    url,
+    body,
+    signal,
+    headers,
+    csrfToken,
+    xsrfCookieName,
+    xsrfHeaderName,
+    credentials,
+    eventName,
+    endSignal = "</stream>",
+    onEvent,
+    onSend,
+    onResponse,
+    onParseError,
+    onBeforeSend,
+}: JsonEventStreamRequest<TEvent, TSendBody>): Promise<boolean> => {
+    const request: RequestInit = {
+        method: "POST",
+        signal,
+        credentials: credentials ?? "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            ...csrfHeaders({ csrfToken, xsrfCookieName, xsrfHeaderName }),
+            ...(headers ?? {}),
+        },
+        body: JSON.stringify(body ?? {}),
+    };
+
+    const modified = onBeforeSend?.(request);
+
+    if (modified === false) {
+        return false;
+    }
+
+    onSend?.();
+
+    const response = await fetch(
+        url,
+        typeof modified === "object" && modified !== null ? modified : request,
+    );
+
+    if (!response.ok) {
+        throw new StreamResponseError(response, await response.text());
+    }
+
+    if (!response.body) {
+        throw new Error("ReadableStream not yet supported in this browser.");
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+
+    if (!contentType.includes("text/event-stream")) {
+        throw new Error(
+            `Expected a text/event-stream response, received "${contentType}".`,
+        );
+    }
+
+    onResponse?.(response);
+
+    const eventNames = eventName === undefined ? null : [eventName].flat();
+
+    await readEventStream(response.body, (frame) => {
+        if (signal.aborted) {
+            return false;
+        }
+
+        // Before the event name filter, so a terminator sent under a
+        // different name still ends the stream.
+        if (frame.data === endSignal) {
+            return false;
+        }
+
+        // A frame with no event field is of type "message".
+        if (
+            eventNames !== null &&
+            !eventNames.includes(frame.event ?? "message")
+        ) {
+            return true;
+        }
+
+        let event: TEvent;
+
+        try {
+            event = JSON.parse(frame.data) as TEvent;
+        } catch (error) {
+            onParseError?.(error as Error, frame.data);
+
+            return true;
+        }
+
+        // Outside the try, so a throw from the caller is not mistaken for
+        // a malformed frame.
+        onEvent(event);
+
+        return true;
+    });
+
+    if (signal.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    return true;
+};

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -19,6 +19,27 @@ export type EventStreamState = {
     messageParts: readonly string[];
 };
 
+export type JsonEventStreamOptions<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    initialInput?: TSendBody;
+    onEvent?: (event: TEvent) => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onCancel?: () => void;
+    onFinish?: () => void;
+    onError?: (error: Error) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+
 export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     id?: string;
     initialInput?: TSendBody;

--- a/packages/svelte/src/useJsonEventStream.svelte.ts
+++ b/packages/svelte/src/useJsonEventStream.svelte.ts
@@ -1,0 +1,166 @@
+import { get, writable } from "svelte/store";
+import { streamJsonEvents } from "./streams/jsonEvents";
+import { JsonEventStreamOptions } from "./types";
+
+export type JsonEventStreamState<TEvent = unknown> = {
+    events: TEvent[];
+    isFetching: boolean;
+    isStreaming: boolean;
+};
+
+export type JsonEventStream<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    subscribe: (
+        run: (value: JsonEventStreamState<TEvent>) => void,
+    ) => () => void;
+    send: (body?: TSendBody) => Promise<void>;
+    cancel: () => void;
+    clearEvents: () => void;
+};
+
+/**
+ * Creates a reactive stream that posts a body and reads JSON events back.
+ * Returns a Svelte store: use `$stream` in templates so the component re-renders when events arrive.
+ *
+ * @param url - The URL to POST to (or a getter for reactive URLs)
+ * @param options - Stream options (initialInput, callbacks, etc.)
+ * @returns A store-like object: subscribe to react to changes, plus send, cancel, clearEvents
+ *
+ * @see https://laravel.com/docs/responses#event-streams
+ */
+export const useJsonEventStream = <
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+>(
+    url: string | (() => string),
+    options: JsonEventStreamOptions<TEvent, TSendBody> = {},
+): JsonEventStream<TEvent, TSendBody> => {
+    const getUrl = typeof url === "function" ? url : () => url;
+
+    const store = writable<JsonEventStreamState<TEvent>>({
+        events: [],
+        isFetching: false,
+        isStreaming: false,
+    });
+
+    let controller: AbortController | null = null;
+
+    const patch = (state: Partial<JsonEventStreamState<TEvent>>) => {
+        store.update((current) => ({ ...current, ...state }));
+    };
+
+    const clearEvents = () => {
+        patch({ events: [] });
+    };
+
+    const cancel = () => {
+        if (controller === null) {
+            return;
+        }
+
+        controller.abort();
+        controller = null;
+
+        patch({ isFetching: false, isStreaming: false });
+
+        options.onCancel?.();
+    };
+
+    const finish = () => {
+        controller = null;
+
+        patch({ isFetching: false, isStreaming: false });
+
+        options.onFinish?.();
+    };
+
+    const send = async (body?: TSendBody) => {
+        cancel();
+
+        const pending = new AbortController();
+
+        try {
+            const sent = await streamJsonEvents<TEvent, TSendBody>({
+                url: getUrl(),
+                body,
+                signal: pending.signal,
+                headers: options.headers,
+                csrfToken: options.csrfToken,
+                xsrfCookieName: options.xsrfCookieName,
+                xsrfHeaderName: options.xsrfHeaderName,
+                credentials: options.credentials,
+                eventName: options.eventName,
+                endSignal: options.endSignal,
+                onBeforeSend: options.onBeforeSend,
+                onParseError: options.onParseError,
+                onSend: () => {
+                    controller = pending;
+
+                    patch({ events: [], isFetching: true });
+                },
+                onResponse: (response) => {
+                    patch({ isFetching: false, isStreaming: true });
+
+                    options.onResponse?.(response);
+                },
+                onEvent: (event) => {
+                    patch({ events: [...get(store).events, event] });
+
+                    options.onEvent?.(event);
+                },
+            });
+
+            if (sent) {
+                finish();
+            }
+        } catch (error) {
+            if ((error as Error).name === "AbortError") {
+                return;
+            }
+
+            patch({ isFetching: false, isStreaming: false });
+
+            options.onError?.(error as Error);
+
+            finish();
+        }
+    };
+
+    let currentUrl = getUrl();
+
+    $effect.root(() => {
+        $effect(() => {
+            window.addEventListener("beforeunload", cancel);
+
+            if (options.initialInput) {
+                void send(options.initialInput);
+            }
+
+            return () => {
+                window.removeEventListener("beforeunload", cancel);
+
+                cancel();
+            };
+        });
+
+        $effect(() => {
+            const newUrl = getUrl();
+
+            if (newUrl !== currentUrl) {
+                currentUrl = newUrl;
+
+                cancel();
+                clearEvents();
+            }
+        });
+    });
+
+    return {
+        subscribe: store.subscribe,
+        send,
+        cancel,
+        clearEvents,
+    };
+};

--- a/packages/svelte/tests/readEventStream.test.ts
+++ b/packages/svelte/tests/readEventStream.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { readEventStream, StreamFrame } from "../src/streams/events";
+
+const bodyOf = (
+    chunks: string[],
+    cancel?: () => void,
+): ReadableStream<Uint8Array> =>
+    new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks) {
+                controller.enqueue(new TextEncoder().encode(chunk));
+            }
+
+            controller.close();
+        },
+        cancel,
+    });
+
+const framesOf = async (chunks: string[]): Promise<StreamFrame[]> => {
+    const frames: StreamFrame[] = [];
+
+    await readEventStream(bodyOf(chunks), (frame) => {
+        frames.push(frame);
+
+        return true;
+    });
+
+    return frames;
+};
+
+describe("readEventStream", () => {
+    it("discards a frame that never reached its blank line", async () => {
+        expect(await framesOf(["data: one\n\ndata: trunc"])).toEqual([
+            { event: null, id: null, data: "one" },
+        ]);
+    });
+
+    it("cancels the body when the handler stops reading", async () => {
+        const cancel = vi.fn();
+
+        // Left open, the way a server still writing after a terminator would
+        // leave it. Without the cancel it streams into a body nobody reads...
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+            },
+            cancel,
+        });
+
+        await readEventStream(body, () => false);
+
+        expect(cancel).toHaveBeenCalled();
+    });
+
+    it("reads the fields of a frame", async () => {
+        expect(
+            await framesOf(["id: 7\nevent: update\ndata: hello\n\n"]),
+        ).toEqual([{ event: "update", id: "7", data: "hello" }]);
+    });
+
+    it("joins multi-line data and skips comments and blank lines", async () => {
+        expect(await framesOf([": ping\ndata: one\ndata: two\n\n"])).toEqual([
+            { event: null, id: null, data: "one\ntwo" },
+        ]);
+    });
+
+    it("strips only the single space after a field's colon", async () => {
+        expect(await framesOf(["data:  padded \n\n"])).toEqual([
+            { event: null, id: null, data: " padded " },
+        ]);
+    });
+
+    it("reads a frame terminated with CRLF", async () => {
+        expect(await framesOf(["event: update\r\ndata: one\r\n\r\n"])).toEqual([
+            { event: "update", id: null, data: "one" },
+        ]);
+    });
+
+    it("reads a CRLF pair split across two chunks", async () => {
+        expect(
+            await framesOf(["data: one\r", "\n\r\ndata: two\r\n\r\n"]),
+        ).toEqual([
+            { event: null, id: null, data: "one" },
+            { event: null, id: null, data: "two" },
+        ]);
+    });
+
+    it("carries the last event id forward to later frames", async () => {
+        // The last event ID buffer belongs to the stream and is not reset when
+        // an event is dispatched...
+        expect(await framesOf(["id: 7\ndata: one\n\ndata: two\n\n"])).toEqual([
+            { event: null, id: "7", data: "one" },
+            { event: null, id: "7", data: "two" },
+        ]);
+    });
+
+    it("takes the id from a frame that dispatches nothing", async () => {
+        // The id is recorded before the frame is dropped for carrying no data...
+        expect(await framesOf(["id: 7\n\ndata: one\n\n"])).toEqual([
+            { event: null, id: "7", data: "one" },
+        ]);
+    });
+
+    it("ignores an id containing a NULL", async () => {
+        expect(
+            await framesOf(["id: 7\n\nid: a\u0000b\ndata: one\n\n"]),
+        ).toEqual([{ event: null, id: "7", data: "one" }]);
+    });
+
+    it("skips a frame that carries no data lines", async () => {
+        expect(await framesOf(["event: ping\n\ndata: one\n\n"])).toEqual([
+            { event: null, id: null, data: "one" },
+        ]);
+    });
+});

--- a/packages/svelte/tests/streamJsonEvents.test.ts
+++ b/packages/svelte/tests/streamJsonEvents.test.ts
@@ -1,0 +1,297 @@
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+import {
+    StreamResponseError,
+    streamJsonEvents,
+} from "../src/streams/jsonEvents";
+
+type TestEvent = { type: string };
+
+describe("streamJsonEvents", () => {
+    const url = "/chat";
+
+    const streamOf = (chunks: string[], duration = 5) =>
+        new HttpResponse(
+            new ReadableStream({
+                async start(controller) {
+                    for (const chunk of chunks) {
+                        await delay(duration);
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+
+                    controller.close();
+                },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+    const server = setupServer();
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("hands each event to the caller without collecting them", async () => {
+        const seen: TestEvent[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const sent = await streamJsonEvents<TestEvent>({
+            url,
+            body: { message: "Hello" },
+            signal: new AbortController().signal,
+            onEvent: (event) => seen.push(event),
+        });
+
+        expect(sent).toBe(true);
+        expect(seen).toEqual([{ type: "one" }, { type: "two" }]);
+    });
+
+    it("resolves false when onBeforeSend refuses the request", async () => {
+        const handler = vi.fn(() => streamOf(["data: </stream>\n\n"]));
+
+        server.use(http.post(url, handler));
+
+        const sent = await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => false,
+            onEvent: () => undefined,
+        });
+
+        expect(sent).toBe(false);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("calls onSend once the request is committed", async () => {
+        const order: string[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => {
+                order.push("before");
+            },
+            onSend: () => order.push("send"),
+            onEvent: () => order.push("event"),
+        });
+
+        expect(order).toEqual(["before", "send", "event"]);
+    });
+
+    it("does not call onSend when onBeforeSend refuses", async () => {
+        const onSend = vi.fn();
+
+        server.use(http.post(url, () => streamOf(["data: </stream>\n\n"])));
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => false,
+            onSend,
+            onEvent: () => undefined,
+        });
+
+        expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("honors a renamed XSRF cookie and header", async () => {
+        document.cookie = "MY-TOKEN=renamed";
+
+        let capturedHeaders: Headers | undefined;
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf(["data: </stream>\n\n"]);
+            }),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            xsrfCookieName: "MY-TOKEN",
+            xsrfHeaderName: "X-MY-TOKEN",
+            onEvent: () => undefined,
+        });
+
+        document.cookie = "MY-TOKEN=; max-age=0";
+
+        expect(capturedHeaders?.get("X-MY-TOKEN")).toBe("renamed");
+        expect(capturedHeaders?.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
+    it("throws the body of a non-OK response", async () => {
+        server.use(
+            http.post(url, () => HttpResponse.text("Boom", { status: 422 })),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => undefined,
+            }),
+        ).rejects.toThrow("Boom");
+    });
+
+    it("carries the failed response on the thrown error", async () => {
+        server.use(
+            http.post(url, () =>
+                HttpResponse.json({ message: "Nope" }, { status: 422 }),
+            ),
+        );
+
+        const error = await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onEvent: () => undefined,
+        }).catch((thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(StreamResponseError);
+        expect((error as StreamResponseError).status).toBe(422);
+        expect(JSON.parse((error as StreamResponseError).body)).toEqual({
+            message: "Nope",
+        });
+    });
+
+    it("throws when the response is not an event stream", async () => {
+        // A login page or proxy error answering 200 with HTML would otherwise
+        // finish reporting nothing at all...
+        server.use(
+            http.post(url, () =>
+                HttpResponse.html("<html>Log in</html>", { status: 200 }),
+            ),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => undefined,
+            }),
+        ).rejects.toThrow(/text\/event-stream/);
+    });
+
+    it("reports a malformed frame through onParseError and keeps reading", async () => {
+        const onParseError = vi.fn();
+        const seen: TestEvent[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    "data: not json\n\n",
+                    'data: {"type":"after"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onParseError,
+            onEvent: (event) => seen.push(event),
+        });
+
+        expect(onParseError).toHaveBeenCalledTimes(1);
+        expect(onParseError.mock.calls[0][1]).toBe("not json");
+        expect(seen).toEqual([{ type: "after" }]);
+    });
+
+    it("stops promptly when the signal aborts before any frame arrives", async () => {
+        const controller = new AbortController();
+        const onEvent = vi.fn();
+
+        // fetch errors the response body when its signal aborts, so the
+        // pending read rejects rather than waiting for a chunk...
+        server.use(
+            http.post(url, () => streamOf(['data: {"type":"one"}\n\n'], 5_000)),
+        );
+
+        const promise = streamJsonEvents<TestEvent>({
+            url,
+            signal: controller.signal,
+            onEvent,
+        });
+
+        controller.abort();
+
+        await expect(promise).rejects.toThrow();
+
+        expect(onEvent).not.toHaveBeenCalled();
+    }, 2_000);
+
+    it("stops reading when the signal aborts", async () => {
+        const seen: TestEvent[] = [];
+        const controller = new AbortController();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(
+                    [
+                        'data: {"type":"one"}\n\n',
+                        'data: {"type":"two"}\n\n',
+                        "data: </stream>\n\n",
+                    ],
+                    30,
+                ),
+            ),
+        );
+
+        const promise = streamJsonEvents<TestEvent>({
+            url,
+            signal: controller.signal,
+            onEvent: (event) => {
+                seen.push(event);
+                controller.abort();
+            },
+        });
+
+        await expect(promise).rejects.toThrow();
+
+        expect(seen).toEqual([{ type: "one" }]);
+    });
+
+    it("does not treat a throw from onEvent as a malformed frame", async () => {
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => {
+                    throw new Error("caller exploded");
+                },
+            }),
+        ).rejects.toThrow("caller exploded");
+    });
+});

--- a/packages/svelte/tests/useJsonEventStream.test.ts
+++ b/packages/svelte/tests/useJsonEventStream.test.ts
@@ -1,0 +1,531 @@
+import { get } from "svelte/store";
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+import {
+    JsonEventStream,
+    JsonEventStreamState,
+    useJsonEventStream,
+} from "../src/useJsonEventStream.svelte";
+
+type TestEvent = { type: string };
+
+const state = (
+    stream: JsonEventStream<TestEvent>,
+): JsonEventStreamState<TestEvent> => get(stream);
+
+describe("useJsonEventStream", () => {
+    const url = "/chat";
+
+    const streamOf = (chunks: string[], duration = 5) =>
+        new HttpResponse(
+            new ReadableStream({
+                async start(controller) {
+                    for (const chunk of chunks) {
+                        await delay(duration);
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+
+                    controller.close();
+                },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+    const server = setupServer();
+
+    beforeAll(() => server.listen());
+    afterEach(() => {
+        vi.clearAllMocks();
+        server.resetHandlers();
+    });
+    afterAll(() => server.close());
+
+    it("posts a body and parses each frame as its own event", async () => {
+        const onFinish = vi.fn();
+        let capturedBody: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedBody = await request.json();
+
+                return streamOf([
+                    'data: {"type":"start"}\n\n',
+                    'data: {"type":"delta"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send({ message: "Hello" });
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedBody).toEqual({ message: "Hello" });
+        expect(state(stream).events).toEqual([
+            { type: "start" },
+            { type: "delta" },
+        ]);
+        expect(state(stream).isFetching).toBe(false);
+        expect(state(stream).isStreaming).toBe(false);
+    });
+
+    it("reads a stream shaped like Laravel's eventStream helper", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: update\ndata: {"type":"one"}\n\n',
+                    'event: update\ndata: {"type":"two"}\n\n',
+                    "event: update\ndata: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([
+            { type: "one" },
+            { type: "two" },
+        ]);
+    });
+
+    it("only keeps the named events when an event name is given", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: token\ndata: {"type":"kept"}\n\n',
+                    'event: ping\ndata: {"type":"dropped"}\n\n',
+                    'data: {"type":"unnamed"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            eventName: "token",
+            onFinish,
+        });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "kept" }]);
+    });
+
+    it("joins frames split across chunk boundaries", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"ty',
+                    'pe":"split"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "split" }]);
+    });
+
+    it("reads frames terminated with CRLF", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: update\r\ndata: {"type":"crlf"}\r\n\r\n',
+                    "data: </stream>\r\n\r\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "crlf" }]);
+    });
+
+    it("reads a CRLF pair split across two chunks", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\r',
+                    '\n\r\ndata: {"type":"two"}\r\n\r\n',
+                    "data: </stream>\r\n\r\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([
+            { type: "one" },
+            { type: "two" },
+        ]);
+    });
+
+    it("joins multi-line data and ignores comments", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    ': keep-alive\ndata: {"type":\ndata: "multiline"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "multiline" }]);
+    });
+
+    it("accepts a data field written without a space", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(['data:{"type":"tight"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "tight" }]);
+    });
+
+    it("drops a malformed frame without ending the stream", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    "data: not json\n\n",
+                    'data: {"type":"after"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "after" }]);
+    });
+
+    it("calls onEvent as each frame arrives", async () => {
+        const onEvent = vi.fn();
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        useJsonEventStream<TestEvent>(url, { onEvent, onFinish }).send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(onEvent).toHaveBeenCalledTimes(2);
+        expect(onEvent).toHaveBeenNthCalledWith(1, { type: "one" });
+        expect(onEvent).toHaveBeenNthCalledWith(2, { type: "two" });
+    });
+
+    it("stops reading at the end signal", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"before"}\n\n',
+                    "data: </stream>\n\n",
+                    'data: {"type":"after"}\n\n',
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "before" }]);
+    });
+
+    it("honors a custom end signal", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"before"}\n\n',
+                    "data: [DONE]\n\n",
+                    'data: {"type":"after"}\n\n',
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            endSignal: "[DONE]",
+            onFinish,
+        });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([{ type: "before" }]);
+    });
+
+    it("finishes when the body closes without an end signal", async () => {
+        const onFinish = vi.fn();
+
+        // laravel/ai's AG-UI protocol sends no terminator frame, so the stream
+        // simply ends when the body does...
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                ]),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onFinish });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(state(stream).events).toEqual([
+            { type: "one" },
+            { type: "two" },
+        ]);
+        expect(state(stream).isStreaming).toBe(false);
+    });
+
+    it("sends the initial input on mount", async () => {
+        const onFinish = vi.fn();
+        let capturedBody: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedBody = await request.json();
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            initialInput: { message: "Hello" },
+            onFinish,
+        });
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedBody).toEqual({ message: "Hello" });
+        expect(state(stream).events).toEqual([{ type: "one" }]);
+    });
+
+    it("uses the request returned by onBeforeSend", async () => {
+        const onFinish = vi.fn();
+        let capturedHeaders: any;
+
+        const onBeforeSend = vi.fn((request: RequestInit) => ({
+            ...request,
+            headers: {
+                ...(request.headers as Record<string, string>),
+                "X-Custom-Header": "custom-value",
+            },
+        }));
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            onBeforeSend,
+            onFinish,
+        });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedHeaders.get("X-Custom-Header")).toBe("custom-value");
+        expect(state(stream).events).toEqual([{ type: "one" }]);
+    });
+
+    it("does not send when onBeforeSend returns false", async () => {
+        const handler = vi.fn(() =>
+            streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+        );
+
+        server.use(http.post(url, handler));
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            onBeforeSend: () => false,
+        });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(state(stream).isFetching).toBe(false));
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(state(stream).events).toEqual([]);
+    });
+
+    it("reports a non-OK response as an error", async () => {
+        const onError = vi.fn();
+
+        server.use(
+            http.post(url, () => HttpResponse.text("Boom", { status: 422 })),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, { onError });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+
+        expect(onError.mock.calls[0][0].message).toBe("Boom");
+        expect(state(stream).isFetching).toBe(false);
+        expect(state(stream).isStreaming).toBe(false);
+    });
+
+    it("can cancel an in-flight stream", async () => {
+        const onCancel = vi.fn();
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(
+                    [
+                        'data: {"type":"one"}\n\n',
+                        'data: {"type":"two"}\n\n',
+                        "data: </stream>\n\n",
+                    ],
+                    30,
+                ),
+            ),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            onCancel,
+            onFinish,
+        });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(state(stream).events).toHaveLength(1));
+
+        stream.cancel();
+
+        // A cancelled run must not also report itself finished...
+        await new Promise((resolve) => setTimeout(resolve, 80));
+
+        expect(onCancel).toHaveBeenCalled();
+        expect(onFinish).not.toHaveBeenCalled();
+        expect(state(stream).isStreaming).toBe(false);
+        expect(state(stream).events).toEqual([{ type: "one" }]);
+    });
+
+    it("sends the CSRF token and clears events on the next send", async () => {
+        const csrfToken = "test-csrf-token";
+        const onFinish = vi.fn();
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const stream = useJsonEventStream<TestEvent>(url, {
+            csrfToken,
+            onFinish,
+        });
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalledTimes(1));
+
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBe(csrfToken);
+        expect(capturedHeaders.get("Accept")).toBe("text/event-stream");
+        expect(state(stream).events).toHaveLength(1);
+
+        stream.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalledTimes(2));
+
+        expect(state(stream).events).toEqual([{ type: "one" }]);
+    });
+});

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -310,7 +310,7 @@ onMounted(() => {
 
 The `useJsonEventStream` hook allows you to POST a request body and consume the [Server-Sent Events (SSE)](https://laravel.com/docs/responses#event-streams) that come back, parsing each event as JSON as it arrives.
 
-Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this hook sends a `POST` request when you call `send` — so you may pass a body and your CSRF token along with it:
+Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this hook sends a request when you call `send`, so you may pass a body and your CSRF token along with it. All requests are sent as JSON `POST` requests:
 
 ```vue
 <script setup lang="ts">
@@ -329,7 +329,7 @@ const startDeploy = () => {
 <template>
     <div>
         <div v-for="event in events">
-            {{ event.step }} — {{ event.percent }}%
+            {{ event.step }}: {{ event.percent }}%
         </div>
         <div v-if="isFetching">Connecting...</div>
         <div v-if="isStreaming">Deploying...</div>

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -306,6 +306,126 @@ onMounted(() => {
 </template>
 ```
 
+## JSON Event Streams
+
+The `useJsonEventStream` hook allows you to POST a request body and consume the [Server-Sent Events (SSE)](https://laravel.com/docs/responses#event-streams) that come back, parsing each event as JSON as it arrives.
+
+Unlike `useEventStream`, which opens a GET connection as soon as your component mounts, this hook sends a `POST` request when you call `send` — so you may pass a body and your CSRF token along with it:
+
+```vue
+<script setup lang="ts">
+import { useJsonEventStream } from "@laravel/stream-vue";
+
+type Deployment = { step: string; percent: number };
+
+const { events, isFetching, isStreaming, send } =
+    useJsonEventStream<Deployment>("/deploy");
+
+const startDeploy = () => {
+    send({ environment: "production" });
+};
+</script>
+
+<template>
+    <div>
+        <div v-for="event in events">
+            {{ event.step }} — {{ event.percent }}%
+        </div>
+        <div v-if="isFetching">Connecting...</div>
+        <div v-if="isStreaming">Deploying...</div>
+        <button @click="startDeploy">Deploy</button>
+    </div>
+</template>
+```
+
+Each event is passed to the `onEvent` callback as it is received, so you may fold it into your own state instead of using the `events` array:
+
+```vue
+<script setup lang="ts">
+import { useJsonEventStream } from "@laravel/stream-vue";
+import { ref } from "vue";
+
+const percent = ref(0);
+
+const { send } = useJsonEventStream<Deployment>("/deploy", {
+    onEvent: (event) => (percent.value = event.percent),
+});
+</script>
+```
+
+The second argument given to `useJsonEventStream` is an options object that you may use to customize the stream consumption behavior:
+
+```ts
+type JsonEventStreamOptions = {
+    initialInput?: Record<string, any>;
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    onEvent?: (event: TEvent) => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onCancel?: () => void;
+    onFinish?: () => void;
+    onError?: (error: Error) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+```
+
+`eventName` limits the events you receive to those sent under the given name. By default every event is received, including those your server sends without a name.
+
+`endSignal` is the event data that ends the stream, matching the `</stream>` that Laravel's `eventStream` method sends by default.
+
+`onParseError` is called when an event arrives that is not valid JSON. The event is skipped and the stream continues.
+
+`onError` is called when the request fails. A response that never became a stream is passed to the callback as a `StreamResponseError`, which carries the `status` and the raw `body` so you may read your server's error:
+
+```vue
+<script setup lang="ts">
+import { StreamResponseError, useJsonEventStream } from "@laravel/stream-vue";
+
+const { send } = useJsonEventStream("/deploy", {
+    onError: (error) => {
+        if (error instanceof StreamResponseError && error.status === 422) {
+            const { errors } = JSON.parse(error.body);
+        }
+    },
+});
+</script>
+```
+
+You may cancel an in-flight stream using the returned `cancel` function, and the `clearEvents` function may be used to clear the events that have been received so far:
+
+```vue
+<script setup lang="ts">
+import { useJsonEventStream } from "@laravel/stream-vue";
+
+const { events, cancel, clearEvents } = useJsonEventStream("/deploy");
+</script>
+```
+
+### Streaming Without State
+
+If you are folding events into state you already own, the `streamJsonEvents` function does the same work without any of the hook's reactivity:
+
+```ts
+import { streamJsonEvents } from "@laravel/stream-vue";
+
+const controller = new AbortController();
+
+await streamJsonEvents<Deployment>({
+    url: "/deploy",
+    body: { environment: "production" },
+    signal: controller.signal,
+    onEvent: (event) => {
+        //
+    },
+});
+```
+
 ## License
 
 Laravel Stream is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/packages/vue/src/composables/useJsonEventStream.ts
+++ b/packages/vue/src/composables/useJsonEventStream.ts
@@ -1,0 +1,148 @@
+import {
+    MaybeRefOrGetter,
+    onMounted,
+    onUnmounted,
+    readonly,
+    Ref,
+    ref,
+    toRef,
+    watch,
+} from "vue";
+import { streamJsonEvents } from "../streams/jsonEvents";
+import { JsonEventStreamOptions, JsonEventStreamResult } from "../types";
+
+/**
+ * Composable for posting a body and reading a stream of JSON events back
+ *
+ * @param url - The URL to post to
+ * @param options - Options for the stream
+ *
+ * @link https://laravel.com/docs/responses#event-streams
+ *
+ * @returns Result object containing the received events, send, and cancel functions
+ */
+export const useJsonEventStream = <
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+>(
+    url: MaybeRefOrGetter<string>,
+    options: JsonEventStreamOptions<TEvent, TSendBody> = {},
+): JsonEventStreamResult<TEvent, TSendBody> => {
+    const urlRef = toRef(url);
+    const events = ref([]) as Ref<TEvent[]>;
+    const isFetching = ref(false);
+    const isStreaming = ref(false);
+
+    let controller: AbortController | null = null;
+
+    const clearEvents = () => {
+        events.value = [];
+    };
+
+    const cancel = () => {
+        if (controller === null) {
+            return;
+        }
+
+        controller.abort();
+        controller = null;
+
+        isFetching.value = false;
+        isStreaming.value = false;
+
+        options.onCancel?.();
+    };
+
+    const finish = () => {
+        controller = null;
+        isFetching.value = false;
+        isStreaming.value = false;
+
+        options.onFinish?.();
+    };
+
+    const send = async (body?: TSendBody) => {
+        cancel();
+
+        const pending = new AbortController();
+
+        try {
+            const sent = await streamJsonEvents<TEvent, TSendBody>({
+                url: urlRef.value,
+                body,
+                signal: pending.signal,
+                headers: options.headers,
+                csrfToken: options.csrfToken,
+                xsrfCookieName: options.xsrfCookieName,
+                xsrfHeaderName: options.xsrfHeaderName,
+                credentials: options.credentials,
+                eventName: options.eventName,
+                endSignal: options.endSignal,
+                onBeforeSend: options.onBeforeSend,
+                onParseError: options.onParseError,
+                onSend: () => {
+                    clearEvents();
+
+                    controller = pending;
+                    isFetching.value = true;
+                },
+                onResponse: (response) => {
+                    isFetching.value = false;
+                    isStreaming.value = true;
+
+                    options.onResponse?.(response);
+                },
+                onEvent: (event) => {
+                    events.value = [...events.value, event];
+
+                    options.onEvent?.(event);
+                },
+            });
+
+            if (sent) {
+                finish();
+            }
+        } catch (error) {
+            if ((error as Error).name === "AbortError") {
+                return;
+            }
+
+            isFetching.value = false;
+            isStreaming.value = false;
+
+            options.onError?.(error as Error);
+
+            finish();
+        }
+    };
+
+    onMounted(() => {
+        window.addEventListener("beforeunload", cancel);
+
+        if (options.initialInput) {
+            void send(options.initialInput);
+        }
+    });
+
+    onUnmounted(() => {
+        window.removeEventListener("beforeunload", cancel);
+
+        cancel();
+    });
+
+    watch(urlRef, (newUrl: string, oldUrl: string) => {
+        if (newUrl !== oldUrl) {
+            cancel();
+            clearEvents();
+        }
+    });
+
+    return {
+        events: readonly(events) as Readonly<Ref<readonly TEvent[]>>,
+        isFetching: readonly(isFetching),
+        isStreaming: readonly(isStreaming),
+        send,
+        cancel,
+        clearEvents,
+    };
+};

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,2 +1,9 @@
 export { useEventStream } from "./composables/useEventStream";
+export { useJsonEventStream } from "./composables/useJsonEventStream";
+export { csrfHeaders, type CsrfHeaderOptions } from "./streams/csrf";
+export {
+    streamJsonEvents,
+    StreamResponseError,
+    type JsonEventStreamRequest,
+} from "./streams/jsonEvents";
 export { useJsonStream, useStream } from "./composables/useStream";

--- a/packages/vue/src/streams/events.ts
+++ b/packages/vue/src/streams/events.ts
@@ -1,0 +1,126 @@
+export type StreamFrame = {
+    event: string | null;
+    id: string | null;
+    data: string;
+};
+
+export type FrameHandler = (frame: StreamFrame) => boolean;
+
+export const readEventStream = async (
+    body: ReadableStream<Uint8Array>,
+    onFrame: FrameHandler,
+): Promise<void> => {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    let carriageReturn = "";
+
+    // Belongs to the stream rather than the frame: it holds its value until
+    // the server sets it again, and an id counts even on a frame that
+    // dispatches nothing.
+    let lastEventId: string | null = null;
+
+    const dispatchFrame = (frame: string): boolean => {
+        const fields = parseFields(frame);
+
+        if (fields.id !== undefined) {
+            lastEventId = fields.id;
+        }
+
+        if (fields.data === null) {
+            return true;
+        }
+
+        return onFrame({
+            event: fields.event,
+            id: lastEventId,
+            data: fields.data,
+        });
+    };
+
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+
+            if (done) {
+                break;
+            }
+
+            buffer += carriageReturn + decoder.decode(value, { stream: true });
+            carriageReturn = "";
+
+            // Held back so a CRLF split across two reads is not turned
+            // into two line breaks, halving one frame.
+            if (buffer.endsWith("\r")) {
+                buffer = buffer.slice(0, -1);
+                carriageReturn = "\r";
+            }
+
+            buffer = buffer.replace(/\r\n?/g, "\n");
+
+            let boundary = buffer.indexOf("\n\n");
+
+            while (boundary !== -1) {
+                const frame = buffer.slice(0, boundary);
+
+                buffer = buffer.slice(boundary + 2);
+
+                if (!dispatchFrame(frame)) {
+                    // Not awaited: a source mid-write may not settle its
+                    // cancel until it finishes.
+                    void reader.cancel().catch(() => undefined);
+
+                    return;
+                }
+
+                boundary = buffer.indexOf("\n\n");
+            }
+        }
+
+        // Anything left never reached its blank line, and an incomplete
+        // frame is discarded at end of file.
+    } finally {
+        reader.releaseLock();
+    }
+};
+
+type ParsedFields = {
+    event: string | null;
+    id: string | undefined;
+    data: string | null;
+};
+
+/**
+ * @link https://html.spec.whatwg.org/multipage/server-sent-events.html
+ */
+const parseFields = (frame: string): ParsedFields => {
+    const data: string[] = [];
+
+    let event: string | null = null;
+    let id: string | undefined;
+
+    for (const line of frame.split("\n")) {
+        if (line === "" || line.startsWith(":")) {
+            continue;
+        }
+
+        const colon = line.indexOf(":");
+        const field = colon === -1 ? line : line.slice(0, colon);
+        const value =
+            colon === -1 ? "" : stripLeadingSpace(line.slice(colon + 1));
+
+        if (field === "data") {
+            data.push(value);
+        } else if (field === "event") {
+            event = value;
+        } else if (field === "id" && !value.includes("\u0000")) {
+            id = value;
+        }
+    }
+
+    return { event, id, data: data.length === 0 ? null : data.join("\n") };
+};
+
+const stripLeadingSpace = (value: string): string =>
+    value.startsWith(" ") ? value.slice(1) : value;

--- a/packages/vue/src/streams/jsonEvents.ts
+++ b/packages/vue/src/streams/jsonEvents.ts
@@ -1,0 +1,161 @@
+import { csrfHeaders } from "./csrf";
+import { readEventStream } from "./events";
+
+export class StreamResponseError extends Error {
+    constructor(
+        public readonly response: Response,
+        public readonly body: string,
+    ) {
+        super(
+            body || `The stream request failed with status ${response.status}.`,
+        );
+
+        this.name = "StreamResponseError";
+    }
+
+    get status(): number {
+        return this.response.status;
+    }
+}
+
+export type JsonEventStreamRequest<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    url: string;
+    body?: TSendBody;
+    signal: AbortSignal;
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    onEvent: (event: TEvent) => void;
+    onSend?: () => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+
+/**
+ * Post a body and read a stream of JSON events back
+ *
+ * The primitive `useJsonEventStream` is built on, for events folded into state
+ * the caller already owns rather than collected into an array.
+ *
+ * @param request - The URL, body, signal and callbacks for the stream
+ *
+ * @link https://laravel.com/docs/responses#event-streams
+ *
+ * @returns False when onBeforeSend refused the request, otherwise true
+ */
+export const streamJsonEvents = async <
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+>({
+    url,
+    body,
+    signal,
+    headers,
+    csrfToken,
+    xsrfCookieName,
+    xsrfHeaderName,
+    credentials,
+    eventName,
+    endSignal = "</stream>",
+    onEvent,
+    onSend,
+    onResponse,
+    onParseError,
+    onBeforeSend,
+}: JsonEventStreamRequest<TEvent, TSendBody>): Promise<boolean> => {
+    const request: RequestInit = {
+        method: "POST",
+        signal,
+        credentials: credentials ?? "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            ...csrfHeaders({ csrfToken, xsrfCookieName, xsrfHeaderName }),
+            ...(headers ?? {}),
+        },
+        body: JSON.stringify(body ?? {}),
+    };
+
+    const modified = onBeforeSend?.(request);
+
+    if (modified === false) {
+        return false;
+    }
+
+    onSend?.();
+
+    const response = await fetch(
+        url,
+        typeof modified === "object" && modified !== null ? modified : request,
+    );
+
+    if (!response.ok) {
+        throw new StreamResponseError(response, await response.text());
+    }
+
+    if (!response.body) {
+        throw new Error("ReadableStream not yet supported in this browser.");
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+
+    if (!contentType.includes("text/event-stream")) {
+        throw new Error(
+            `Expected a text/event-stream response, received "${contentType}".`,
+        );
+    }
+
+    onResponse?.(response);
+
+    const eventNames = eventName === undefined ? null : [eventName].flat();
+
+    await readEventStream(response.body, (frame) => {
+        if (signal.aborted) {
+            return false;
+        }
+
+        // Before the event name filter, so a terminator sent under a
+        // different name still ends the stream.
+        if (frame.data === endSignal) {
+            return false;
+        }
+
+        // A frame with no event field is of type "message".
+        if (
+            eventNames !== null &&
+            !eventNames.includes(frame.event ?? "message")
+        ) {
+            return true;
+        }
+
+        let event: TEvent;
+
+        try {
+            event = JSON.parse(frame.data) as TEvent;
+        } catch (error) {
+            onParseError?.(error as Error, frame.data);
+
+            return true;
+        }
+
+        // Outside the try, so a throw from the caller is not mistaken for
+        // a malformed frame.
+        onEvent(event);
+
+        return true;
+    });
+
+    if (signal.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    return true;
+};

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -17,6 +17,39 @@ export type EventStreamResult = {
     clearMessage: () => void;
 };
 
+export type JsonEventStreamOptions<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    headers?: Record<string, string>;
+    csrfToken?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    credentials?: RequestCredentials;
+    eventName?: string | string[];
+    endSignal?: string;
+    initialInput?: TSendBody;
+    onEvent?: (event: TEvent) => void;
+    onResponse?: (response: Response) => void;
+    onParseError?: (error: Error, data: string) => void;
+    onCancel?: () => void;
+    onFinish?: () => void;
+    onError?: (error: Error) => void;
+    onBeforeSend?: (request: RequestInit) => boolean | RequestInit | void;
+};
+
+export type JsonEventStreamResult<
+    TEvent = unknown,
+    TSendBody extends Record<string, any> = {},
+> = {
+    events: Readonly<Ref<readonly TEvent[]>>;
+    isFetching: Readonly<Ref<boolean>>;
+    isStreaming: Readonly<Ref<boolean>>;
+    send: (body?: TSendBody) => Promise<void>;
+    cancel: () => void;
+    clearEvents: () => void;
+};
+
 export type StreamOptions<TSendBody extends Record<string, any> = {}> = {
     id?: string;
     initialInput?: TSendBody;

--- a/packages/vue/tests/readEventStream.test.ts
+++ b/packages/vue/tests/readEventStream.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { readEventStream, StreamFrame } from "../src/streams/events";
+
+const bodyOf = (
+    chunks: string[],
+    cancel?: () => void,
+): ReadableStream<Uint8Array> =>
+    new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks) {
+                controller.enqueue(new TextEncoder().encode(chunk));
+            }
+
+            controller.close();
+        },
+        cancel,
+    });
+
+const framesOf = async (chunks: string[]): Promise<StreamFrame[]> => {
+    const frames: StreamFrame[] = [];
+
+    await readEventStream(bodyOf(chunks), (frame) => {
+        frames.push(frame);
+
+        return true;
+    });
+
+    return frames;
+};
+
+describe("readEventStream", () => {
+    it("discards a frame that never reached its blank line", async () => {
+        expect(await framesOf(["data: one\n\ndata: trunc"])).toEqual([
+            { event: null, id: null, data: "one" },
+        ]);
+    });
+
+    it("cancels the body when the handler stops reading", async () => {
+        const cancel = vi.fn();
+
+        // Left open, the way a server still writing after a terminator would
+        // leave it. Without the cancel it streams into a body nobody reads...
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+            },
+            cancel,
+        });
+
+        await readEventStream(body, () => false);
+
+        expect(cancel).toHaveBeenCalled();
+    });
+
+    it("reads the fields of a frame", async () => {
+        expect(
+            await framesOf(["id: 7\nevent: update\ndata: hello\n\n"]),
+        ).toEqual([{ event: "update", id: "7", data: "hello" }]);
+    });
+
+    it("joins multi-line data and skips comments and blank lines", async () => {
+        expect(await framesOf([": ping\ndata: one\ndata: two\n\n"])).toEqual([
+            { event: null, id: null, data: "one\ntwo" },
+        ]);
+    });
+
+    it("strips only the single space after a field's colon", async () => {
+        expect(await framesOf(["data:  padded \n\n"])).toEqual([
+            { event: null, id: null, data: " padded " },
+        ]);
+    });
+
+    it("reads a frame terminated with CRLF", async () => {
+        expect(await framesOf(["event: update\r\ndata: one\r\n\r\n"])).toEqual([
+            { event: "update", id: null, data: "one" },
+        ]);
+    });
+
+    it("reads a CRLF pair split across two chunks", async () => {
+        expect(
+            await framesOf(["data: one\r", "\n\r\ndata: two\r\n\r\n"]),
+        ).toEqual([
+            { event: null, id: null, data: "one" },
+            { event: null, id: null, data: "two" },
+        ]);
+    });
+
+    it("carries the last event id forward to later frames", async () => {
+        // The last event ID buffer belongs to the stream and is not reset when
+        // an event is dispatched...
+        expect(await framesOf(["id: 7\ndata: one\n\ndata: two\n\n"])).toEqual([
+            { event: null, id: "7", data: "one" },
+            { event: null, id: "7", data: "two" },
+        ]);
+    });
+
+    it("takes the id from a frame that dispatches nothing", async () => {
+        // The id is recorded before the frame is dropped for carrying no data...
+        expect(await framesOf(["id: 7\n\ndata: one\n\n"])).toEqual([
+            { event: null, id: "7", data: "one" },
+        ]);
+    });
+
+    it("ignores an id containing a NULL", async () => {
+        expect(
+            await framesOf(["id: 7\n\nid: a\u0000b\ndata: one\n\n"]),
+        ).toEqual([{ event: null, id: "7", data: "one" }]);
+    });
+
+    it("skips a frame that carries no data lines", async () => {
+        expect(await framesOf(["event: ping\n\ndata: one\n\n"])).toEqual([
+            { event: null, id: null, data: "one" },
+        ]);
+    });
+});

--- a/packages/vue/tests/sources.test.ts
+++ b/packages/vue/tests/sources.test.ts
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const packages = ["vue", "react", "svelte"];
+const root = join(import.meta.dirname, "..", "..");
+
+const typescriptFilesIn = (directory: string): string[] =>
+    readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return typescriptFilesIn(path);
+        }
+
+        return entry.name.endsWith(".ts") ? [path] : [];
+    });
+
+/**
+ * The framework-agnostic sources are copied into each package rather than
+ * shared, following the existing dispatch.ts / store.ts convention. Nothing
+ * but this test stops one copy being fixed and the other two being forgotten.
+ */
+describe("shared sources", () => {
+    const shared = ["csrf.ts", "events.ts", "jsonEvents.ts"];
+
+    const digest = (pkg: string, file: string): string =>
+        createHash("sha256")
+            .update(readFileSync(join(root, pkg, "src", "streams", file)))
+            .digest("hex");
+
+    it.each(shared)("keeps %s identical across every package", (file) => {
+        const digests = packages.map((pkg) => digest(pkg, file));
+
+        expect(new Set(digests).size).toBe(1);
+    });
+});
+
+describe("source files", () => {
+    /**
+     * A NUL written into a source file rather than escaped still
+     * compiles, formats and passes tests, but turns the file binary to every
+     * text tool that reads it.
+     */
+    it("contains no literal NUL bytes", () => {
+        const offenders = packages
+            .flatMap((pkg) => [
+                ...typescriptFilesIn(join(root, pkg, "src")),
+                ...typescriptFilesIn(join(root, pkg, "tests")),
+            ])
+            .filter((path) => readFileSync(path).includes(0))
+            .map((path) => relative(root, path));
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/packages/vue/tests/streamJsonEvents.test.ts
+++ b/packages/vue/tests/streamJsonEvents.test.ts
@@ -1,0 +1,297 @@
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+import {
+    StreamResponseError,
+    streamJsonEvents,
+} from "../src/streams/jsonEvents";
+
+type TestEvent = { type: string };
+
+describe("streamJsonEvents", () => {
+    const url = "/chat";
+
+    const streamOf = (chunks: string[], duration = 5) =>
+        new HttpResponse(
+            new ReadableStream({
+                async start(controller) {
+                    for (const chunk of chunks) {
+                        await delay(duration);
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+
+                    controller.close();
+                },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+    const server = setupServer();
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("hands each event to the caller without collecting them", async () => {
+        const seen: TestEvent[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const sent = await streamJsonEvents<TestEvent>({
+            url,
+            body: { message: "Hello" },
+            signal: new AbortController().signal,
+            onEvent: (event) => seen.push(event),
+        });
+
+        expect(sent).toBe(true);
+        expect(seen).toEqual([{ type: "one" }, { type: "two" }]);
+    });
+
+    it("resolves false when onBeforeSend refuses the request", async () => {
+        const handler = vi.fn(() => streamOf(["data: </stream>\n\n"]));
+
+        server.use(http.post(url, handler));
+
+        const sent = await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => false,
+            onEvent: () => undefined,
+        });
+
+        expect(sent).toBe(false);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("calls onSend once the request is committed", async () => {
+        const order: string[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => {
+                order.push("before");
+            },
+            onSend: () => order.push("send"),
+            onEvent: () => order.push("event"),
+        });
+
+        expect(order).toEqual(["before", "send", "event"]);
+    });
+
+    it("does not call onSend when onBeforeSend refuses", async () => {
+        const onSend = vi.fn();
+
+        server.use(http.post(url, () => streamOf(["data: </stream>\n\n"])));
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onBeforeSend: () => false,
+            onSend,
+            onEvent: () => undefined,
+        });
+
+        expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("honors a renamed XSRF cookie and header", async () => {
+        document.cookie = "MY-TOKEN=renamed";
+
+        let capturedHeaders: Headers | undefined;
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf(["data: </stream>\n\n"]);
+            }),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            xsrfCookieName: "MY-TOKEN",
+            xsrfHeaderName: "X-MY-TOKEN",
+            onEvent: () => undefined,
+        });
+
+        document.cookie = "MY-TOKEN=; max-age=0";
+
+        expect(capturedHeaders?.get("X-MY-TOKEN")).toBe("renamed");
+        expect(capturedHeaders?.get("X-XSRF-TOKEN")).toBeNull();
+    });
+
+    it("throws the body of a non-OK response", async () => {
+        server.use(
+            http.post(url, () => HttpResponse.text("Boom", { status: 422 })),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => undefined,
+            }),
+        ).rejects.toThrow("Boom");
+    });
+
+    it("carries the failed response on the thrown error", async () => {
+        server.use(
+            http.post(url, () =>
+                HttpResponse.json({ message: "Nope" }, { status: 422 }),
+            ),
+        );
+
+        const error = await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onEvent: () => undefined,
+        }).catch((thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(StreamResponseError);
+        expect((error as StreamResponseError).status).toBe(422);
+        expect(JSON.parse((error as StreamResponseError).body)).toEqual({
+            message: "Nope",
+        });
+    });
+
+    it("throws when the response is not an event stream", async () => {
+        // A login page or proxy error answering 200 with HTML would otherwise
+        // finish reporting nothing at all...
+        server.use(
+            http.post(url, () =>
+                HttpResponse.html("<html>Log in</html>", { status: 200 }),
+            ),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => undefined,
+            }),
+        ).rejects.toThrow(/text\/event-stream/);
+    });
+
+    it("reports a malformed frame through onParseError and keeps reading", async () => {
+        const onParseError = vi.fn();
+        const seen: TestEvent[] = [];
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    "data: not json\n\n",
+                    'data: {"type":"after"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        await streamJsonEvents<TestEvent>({
+            url,
+            signal: new AbortController().signal,
+            onParseError,
+            onEvent: (event) => seen.push(event),
+        });
+
+        expect(onParseError).toHaveBeenCalledTimes(1);
+        expect(onParseError.mock.calls[0][1]).toBe("not json");
+        expect(seen).toEqual([{ type: "after" }]);
+    });
+
+    it("stops promptly when the signal aborts before any frame arrives", async () => {
+        const controller = new AbortController();
+        const onEvent = vi.fn();
+
+        // fetch errors the response body when its signal aborts, so the
+        // pending read rejects rather than waiting for a chunk...
+        server.use(
+            http.post(url, () => streamOf(['data: {"type":"one"}\n\n'], 5_000)),
+        );
+
+        const promise = streamJsonEvents<TestEvent>({
+            url,
+            signal: controller.signal,
+            onEvent,
+        });
+
+        controller.abort();
+
+        await expect(promise).rejects.toThrow();
+
+        expect(onEvent).not.toHaveBeenCalled();
+    }, 2_000);
+
+    it("stops reading when the signal aborts", async () => {
+        const seen: TestEvent[] = [];
+        const controller = new AbortController();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(
+                    [
+                        'data: {"type":"one"}\n\n',
+                        'data: {"type":"two"}\n\n',
+                        "data: </stream>\n\n",
+                    ],
+                    30,
+                ),
+            ),
+        );
+
+        const promise = streamJsonEvents<TestEvent>({
+            url,
+            signal: controller.signal,
+            onEvent: (event) => {
+                seen.push(event);
+                controller.abort();
+            },
+        });
+
+        await expect(promise).rejects.toThrow();
+
+        expect(seen).toEqual([{ type: "one" }]);
+    });
+
+    it("does not treat a throw from onEvent as a malformed frame", async () => {
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        await expect(
+            streamJsonEvents<TestEvent>({
+                url,
+                signal: new AbortController().signal,
+                onEvent: () => {
+                    throw new Error("caller exploded");
+                },
+            }),
+        ).rejects.toThrow("caller exploded");
+    });
+});

--- a/packages/vue/tests/useJsonEventStream.test.ts
+++ b/packages/vue/tests/useJsonEventStream.test.ts
@@ -1,0 +1,575 @@
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+import { App, createApp } from "vue";
+import { useJsonEventStream } from "../src/composables/useJsonEventStream";
+
+function withSetup<T>(composable: () => T): [T, App<Element>] {
+    let result;
+
+    const app = createApp({
+        setup() {
+            result = composable();
+            return () => {};
+        },
+    });
+
+    app.mount(document.createElement("div"));
+
+    return [result as T, app];
+}
+
+type TestEvent = { type: string };
+
+describe("useJsonEventStream", () => {
+    const url = "/chat";
+
+    const streamOf = (chunks: string[], duration = 5) =>
+        new HttpResponse(
+            new ReadableStream({
+                async start(controller) {
+                    for (const chunk of chunks) {
+                        await delay(duration);
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+
+                    controller.close();
+                },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+    const server = setupServer();
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("posts a body and parses each frame as its own event", async () => {
+        const onFinish = vi.fn();
+        let capturedBody: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedBody = await request.json();
+
+                return streamOf([
+                    'data: {"type":"start"}\n\n',
+                    'data: {"type":"delta"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send({ message: "Hello" });
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedBody).toEqual({ message: "Hello" });
+        expect(result.events.value).toEqual([
+            { type: "start" },
+            { type: "delta" },
+        ]);
+        expect(result.isFetching.value).toBe(false);
+        expect(result.isStreaming.value).toBe(false);
+    });
+
+    it("reads a stream shaped like Laravel's eventStream helper", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: update\ndata: {"type":"one"}\n\n',
+                    'event: update\ndata: {"type":"two"}\n\n',
+                    "event: update\ndata: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "one" }, { type: "two" }]);
+    });
+
+    it("only keeps the named events when an event name is given", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: token\ndata: {"type":"kept"}\n\n',
+                    'event: ping\ndata: {"type":"dropped"}\n\n',
+                    'data: {"type":"unnamed"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, {
+                eventName: "token",
+                onFinish,
+            }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "kept" }]);
+    });
+
+    it("joins frames split across chunk boundaries", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"ty',
+                    'pe":"split"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "split" }]);
+    });
+
+    it("reads frames terminated with CRLF", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'event: update\r\ndata: {"type":"crlf"}\r\n\r\n',
+                    "data: </stream>\r\n\r\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "crlf" }]);
+    });
+
+    it("reads a CRLF pair split across two chunks", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\r',
+                    '\n\r\ndata: {"type":"two"}\r\n\r\n',
+                    "data: </stream>\r\n\r\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "one" }, { type: "two" }]);
+    });
+
+    it("joins multi-line data and ignores comments", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    ': keep-alive\ndata: {"type":\ndata: "multiline"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "multiline" }]);
+    });
+
+    it("accepts a data field written without a space", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(['data:{"type":"tight"}\n\n', "data: </stream>\n\n"]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "tight" }]);
+    });
+
+    it("drops a malformed frame without ending the stream", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    "data: not json\n\n",
+                    'data: {"type":"after"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "after" }]);
+    });
+
+    it("calls onEvent as each frame arrives", async () => {
+        const onEvent = vi.fn();
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                    "data: </stream>\n\n",
+                ]),
+            ),
+        );
+
+        withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onEvent, onFinish }),
+        )[0].send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(onEvent).toHaveBeenCalledTimes(2);
+        expect(onEvent).toHaveBeenNthCalledWith(1, { type: "one" });
+        expect(onEvent).toHaveBeenNthCalledWith(2, { type: "two" });
+    });
+
+    it("stops reading at the end signal", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"before"}\n\n',
+                    "data: </stream>\n\n",
+                    'data: {"type":"after"}\n\n',
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "before" }]);
+    });
+
+    it("honors a custom end signal", async () => {
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"before"}\n\n',
+                    "data: [DONE]\n\n",
+                    'data: {"type":"after"}\n\n',
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, {
+                endSignal: "[DONE]",
+                onFinish,
+            }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "before" }]);
+    });
+
+    it("finishes when the body closes without an end signal", async () => {
+        const onFinish = vi.fn();
+
+        // laravel/ai's AG-UI protocol sends no terminator frame, so the stream
+        // simply ends when the body does...
+        server.use(
+            http.post(url, () =>
+                streamOf([
+                    'data: {"type":"one"}\n\n',
+                    'data: {"type":"two"}\n\n',
+                ]),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "one" }, { type: "two" }]);
+        expect(result.isStreaming.value).toBe(false);
+    });
+
+    it("discards a frame the body ended in the middle of", async () => {
+        const onFinish = vi.fn();
+
+        // The event-stream algorithm drops an event that never reached its
+        // blank line, so a truncated body cannot deliver a partial frame...
+        server.use(
+            http.post(url, () =>
+                streamOf(['data: {"type":"one"}\n\n', 'data: {"type":"trunc']),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(result.events.value).toEqual([{ type: "one" }]);
+    });
+
+    it("sends the initial input on mount", async () => {
+        const onFinish = vi.fn();
+        let capturedBody: any;
+
+        server.use(
+            http.post(url, async ({ request }) => {
+                capturedBody = await request.json();
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, {
+                initialInput: { message: "Hello" },
+                onFinish,
+            }),
+        );
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedBody).toEqual({ message: "Hello" });
+        expect(result.events.value).toEqual([{ type: "one" }]);
+    });
+
+    it("uses the request returned by onBeforeSend", async () => {
+        const onFinish = vi.fn();
+        let capturedHeaders: any;
+
+        const onBeforeSend = vi.fn((request: RequestInit) => ({
+            ...request,
+            headers: {
+                ...(request.headers as Record<string, string>),
+                "X-Custom-Header": "custom-value",
+            },
+        }));
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onBeforeSend, onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalled());
+
+        expect(capturedHeaders.get("X-Custom-Header")).toBe("custom-value");
+        expect(result.events.value).toEqual([{ type: "one" }]);
+    });
+
+    it("does not send when onBeforeSend returns false", async () => {
+        const handler = vi.fn(() =>
+            streamOf(['data: {"type":"one"}\n\n', "data: </stream>\n\n"]),
+        );
+
+        server.use(http.post(url, handler));
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onBeforeSend: () => false }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(result.isFetching.value).toBe(false));
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.events.value).toEqual([]);
+    });
+
+    it("reports a non-OK response as an error", async () => {
+        const onError = vi.fn();
+
+        server.use(
+            http.post(url, () => HttpResponse.text("Boom", { status: 422 })),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onError }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+
+        expect(onError.mock.calls[0][0].message).toBe("Boom");
+        expect(result.isFetching.value).toBe(false);
+        expect(result.isStreaming.value).toBe(false);
+    });
+
+    it("can cancel an in-flight stream", async () => {
+        const onCancel = vi.fn();
+        const onFinish = vi.fn();
+
+        server.use(
+            http.post(url, () =>
+                streamOf(
+                    [
+                        'data: {"type":"one"}\n\n',
+                        'data: {"type":"two"}\n\n',
+                        "data: </stream>\n\n",
+                    ],
+                    30,
+                ),
+            ),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { onCancel, onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(result.events.value).toHaveLength(1));
+
+        result.cancel();
+
+        // A cancelled run must not also report itself finished...
+        await new Promise((resolve) => setTimeout(resolve, 80));
+
+        expect(onCancel).toHaveBeenCalled();
+        expect(onFinish).not.toHaveBeenCalled();
+        expect(result.isStreaming.value).toBe(false);
+        expect(result.events.value).toEqual([{ type: "one" }]);
+    });
+
+    it("sends the CSRF token and clears events on the next send", async () => {
+        const csrfToken = "test-csrf-token";
+        const onFinish = vi.fn();
+        let capturedHeaders: any;
+
+        server.use(
+            http.post(url, ({ request }) => {
+                capturedHeaders = request.headers;
+
+                return streamOf([
+                    'data: {"type":"one"}\n\n',
+                    "data: </stream>\n\n",
+                ]);
+            }),
+        );
+
+        const [result] = withSetup(() =>
+            useJsonEventStream<TestEvent>(url, { csrfToken, onFinish }),
+        );
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalledTimes(1));
+
+        expect(capturedHeaders.get("X-CSRF-TOKEN")).toBe(csrfToken);
+        expect(capturedHeaders.get("Accept")).toBe("text/event-stream");
+        expect(result.events.value).toHaveLength(1);
+
+        result.send();
+
+        await vi.waitFor(() => expect(onFinish).toHaveBeenCalledTimes(2));
+
+        expect(result.events.value).toEqual([{ type: "one" }]);
+    });
+});


### PR DESCRIPTION
This PR adds `useJsonEventStream`, which posts a request body and parses each Server-Sent Event as it arrives:

```vue
<script setup lang="ts">
import { useJsonEventStream } from "@laravel/stream-vue";

type Deployment = { step: string; percent: number };

const { events, isStreaming, send } =
    useJsonEventStream<Deployment>("/deploy");
</script>

<template>
    <div v-for="event in events">{{ event.step }} — {{ event.percent }}%</div>
    <div v-if="isStreaming">Deploying...</div>
    <button @click="send({ environment: 'production' })">Deploy</button>
</template>
```

The existing hooks each cover half of this. `useStream` posts a body, but hands back the whole response as one concatenated string and only parses JSON once the stream has finished, which an event stream body never survives because the concatenated frames are not valid JSON. `useEventStream` parses each frame as it arrives, but is built on `EventSource`, so it is GET only and cannot carry a body or a CSRF header.

The hook follows `useStream` (same `send`, `cancel`, `isFetching` and `isStreaming`), and the same options for headers, CSRF, credentials, `initialInput` and `onBeforeSend`.

`eventName` and `endSignal` come from `useEventStream`, with `endSignal` defaulting to the `</stream>` that Laravel's `eventStream` method sends.

Events are also passed to an `onEvent` callback as they arrive. For callers folding events into state they already own, `streamJsonEvents` is the same reader without any of the hook's reactivity:

```ts
import { streamJsonEvents } from "@laravel/stream-vue";

const controller = new AbortController();

await streamJsonEvents<Deployment>({
    url: "/deploy",
    body: { environment: "production" },
    signal: controller.signal,
    onEvent: (event) => {
        //
    },
});
```

A response that never became a stream is thrown as a `StreamResponseError` carrying the status and the raw body, so a 422 can be read back into a form.

Frames are parsed following the [event stream algorithm](https://html.spec.whatwg.org/multipage/server-sent-events.html): `event`, `id` and multi-line `data` fields, comments, CRLF line endings, and an incomplete frame at the end of the body is discarded. `useStream` and `useEventStream` are untouched.

Stacked on #44.