### PR TITLE
Bump publish workflow Node version from 20 to 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
             - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
               with:
-                  node-version: "20"
+                  node-version: "22"
                   registry-url: "https://registry.npmjs.org"
                   cache: pnpm
 


### PR DESCRIPTION
## Problem
The `publish` workflow (`.github/workflows/publish.yml`) sets `node-version: "20"`,
which fails when pnpm 11.1.1 is installed via corepack. The failed run shows:

    warn: This version of pnpm requires at least Node.js v22.13. You are using v20.20.2.

    TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING]: A dynamic import callback was not specified.

Failed run: https://github.com/laravel/stream/actions/runs/26769674888

## Fix
Bump `node-version` from `"20"` to `"22"` in `publish.yml`.

## Verification
Reproduced locally:
- `nvm use 20.20.2` + corepack + pnpm 11.1.1 → same warning + `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` error on `pnpm -v` / `pnpm install`
- `nvm use 22` + corepack + pnpm 11.1.1 → `pnpm install`, `pnpm build`, `pnpm test`, `pnpm lint` all pass with no errors/warnings

Note: `tests.yml` and `coding-standards.yml` don't pin a Node version at all, so this
also brings `publish.yml` in line with the rest of CI.